### PR TITLE
feature: NetworkRigidbody (snapshot interpolation)

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
@@ -1,9 +1,11 @@
+using System;
 using UnityEngine;
 
 namespace Mirror.Experimental
 {
     [AddComponentMenu("Network/ Experimental/Network Lerp Rigidbody")]
     [HelpURL("https://mirror-networking.gitbook.io/docs/components/network-lerp-rigidbody")]
+    [Obsolete("Use the new NetworkRigidbody component with Snapshot Interpolation instead.\nSee Components/NetworkTransform2k/NetworkRigidbody")]
     public class NetworkLerpRigidbody : NetworkBehaviour
     {
         [Header("Settings")]

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -5,7 +5,7 @@ namespace Mirror.Experimental
 {
     [AddComponentMenu("Network/ Experimental/Network Rigidbody")]
     [HelpURL("https://mirror-networking.gitbook.io/docs/components/network-rigidbody")]
-    [Obsolete("Use the new NetworkRigidbody component with Snapshot Interpolation instead.")]
+    [Obsolete("Use the new NetworkRigidbody component with Snapshot Interpolation instead.\nSee Components/NetworkTransform2k/NetworkRigidbody")]
     public class NetworkRigidbody : NetworkBehaviour
     {
         [Header("Settings")]

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -1,9 +1,11 @@
+using System;
 using UnityEngine;
 
 namespace Mirror.Experimental
 {
     [AddComponentMenu("Network/ Experimental/Network Rigidbody")]
     [HelpURL("https://mirror-networking.gitbook.io/docs/components/network-rigidbody")]
+    [Obsolete("Use the new NetworkRigidbody component with Snapshot Interpolation instead.")]
     public class NetworkRigidbody : NetworkBehaviour
     {
         [Header("Settings")]

--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
@@ -15,22 +15,42 @@ namespace Mirror
             // who ever has authority moves the Rigidbody with physics.
             // everyone else simply sets it to kinematic.
             // so that only the Transform component is synced.
-            if (isClient)
+
+            // host mode
+            if (isServer && isClient)
             {
-                // on the client, force kinematic if server has authority.
-                // or if another client (not us) has authority.
+                // in host mode, we own it it if:
+                // clientAuthority is disabled (hence server / we own it)
+                // clientAuthority is enabled and we have authority over this object.
+                bool owned = !clientAuthority || IsClientWithAuthority;
+
+                // only set to kinematic if we don't own it
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
-                if (!IsClientWithAuthority)
-                    rb.isKinematic = true;
+                if (!owned) rb.isKinematic = true;
             }
+            // client only
+            else if (isClient)
+            {
+                // on the client, we own it only if clientAuthority is enabled,
+                // and we have authority over this object.
+                bool owned = IsClientWithAuthority;
+
+                // only set to kinematic if we don't own it
+                // otherwise don't touch isKinematic.
+                // the authority owner might use it either way.
+                if (!owned) rb.isKinematic = true;
+            }
+            // server only
             else if (isServer)
             {
-                // on the server, force kinematic if a client has authority.
+                // on the server, we always own it if clientAuthority is disabled.
+                bool owned = !clientAuthority;
+
+                // only set to kinematic if we don't own it
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
-                if (clientAuthority)
-                    rb.isKinematic = true;
+                if (!owned) rb.isKinematic = true;
             }
         }
     }

--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Mirror
+{
+    [RequireComponent(typeof(Rigidbody))]
+    public class NetworkRigidbody : NetworkTransform
+    {
+    }
+}

--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs
@@ -5,5 +5,33 @@ namespace Mirror
     [RequireComponent(typeof(Rigidbody))]
     public class NetworkRigidbody : NetworkTransform
     {
+        // cache the Rigidbody component
+        Rigidbody rb;
+        void Awake() { rb = GetComponent<Rigidbody>(); }
+
+        // FixedUpdate for physics
+        void FixedUpdate()
+        {
+            // who ever has authority moves the Rigidbody with physics.
+            // everyone else simply sets it to kinematic.
+            // so that only the Transform component is synced.
+            if (isClient)
+            {
+                // on the client, force kinematic if server has authority.
+                // or if another client (not us) has authority.
+                // otherwise don't touch isKinematic.
+                // the authority owner might use it either way.
+                if (!IsClientWithAuthority)
+                    rb.isKinematic = true;
+            }
+            else if (isServer)
+            {
+                // on the server, force kinematic if a client has authority.
+                // otherwise don't touch isKinematic.
+                // the authority owner might use it either way.
+                if (clientAuthority)
+                    rb.isKinematic = true;
+            }
+        }
     }
 }

--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs.meta
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkRigidbody.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7bd4b6ec7b524c4daab724e9f74b6e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**NetworkRigidbody** component based on Snapshot Interpolation.
- Rigidbody only ever modifies Transform component
- NetworkTransform already syncs Transform component
- NetworkRigidbody simply inherits from NetworkTransform and sets the RB to kinematic if we don't have authority

before:
https://gyazo.com/f9b6f55768a07a38e52a00d3f66693c8

after:
https://gyazo.com/040f35daf2d488a2ca5fb369e01a59ce

test via:
- change tanks projectile script to set velocity in onstartserver only
- add NetworkRibidbody component
- see if it syncs like above

NOTE: obsoletes the two experimental ones

TODO: NetworkTransformBase helper: 'can I move this?' bool