### PR TITLE
Fix: #3120 Send Interval / Sync Interval Inaccuracy.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -368,7 +368,20 @@ namespace Mirror
                 );
 #endif
 
-                lastServerSendTime = NetworkTime.localTime;
+                // Increment by send interval so that time is not lost due to late sends,
+                // which would accumulate and cause the send rate to be lower than specified.
+                // See issue: #3120
+                lastServerSendTime += sendInterval;
+
+                // Reset lastServerSendTime to current time if lagging behind by at least an entire send interval.
+                // Lagging behind is caused by FPS < send rate or freezes/stutters,
+                // or from not sending updates due to only syncing on change.
+                // Reseting prevents spam sending updates until caught up.
+                if (NetworkTime.localTime - lastServerSendTime > sendInterval)
+                {
+                    lastServerSendTime = NetworkTime.localTime;
+                }
+
 #if onlySyncOnChange_BANDWIDTH_SAVING
                 if (cachedSnapshotComparison)
                 {
@@ -461,7 +474,20 @@ namespace Mirror
                     );
 #endif
 
-                    lastClientSendTime = NetworkTime.localTime;
+                    // Increment by send interval so that time is not lost due to late sends,
+                    // which would accumulate and cause the send rate to be lower than specified.
+                    // See issue: #3120
+                    lastClientSendTime += sendInterval;
+
+                    // Reset lastClientSendTime to current time if lagging behind by at least an entire send interval.
+                    // Lagging behind is caused by FPS < send rate or freezes/stutters,
+                    // or from not sending updates due to only syncing on change.
+                    // Reseting prevents spam sending updates until caught up.
+                    if (NetworkTime.localTime - lastClientSendTime > sendInterval)
+                    {
+                        lastClientSendTime = NetworkTime.localTime;
+                    }
+
 #if onlySyncOnChange_BANDWIDTH_SAVING
                     if (cachedSnapshotComparison)
                     {


### PR DESCRIPTION
Resolves #3120 Send Interval / Sync Interval Inaccuracy.

Improves accuracy of send/sync intervals in NetworkAnimator, NetworkTransformBase, and NetworkBehavior sync vars. 

Implemented enhancement based on @imerr suggestion in https://github.com/vis2k/Mirror/issues/3120#issuecomment-1076226260, instead of my error accumulator suggestion because it was simpler to implement and understand. 

Accuracy of send/sync intervals is improved by using `lastSendTime` to keep track of late sends/syncs, and allowing followup sends/syncs to run slightly early. A threshold, of one sync interval, is used to reset `lastSendTime` in temporary cases of low FPS, freezes, or no changes occurring, to prevent `lastSendTime` from lagging behind afterwards and causing sends every frame.

Under normal circumstances, FPS >= Sync Rate, the overall send/sync rate will more accurately match the developer specified send/sync rate. The pacing between send/sync intervals will also be more consistent with the specified interval. The only real difference, is that send/syncs occasionally send slightly early, < syncInterval, to accommodate for send/syncs that were late. Under abnormal circumstances, FPS < Sync Rate, behavior will be the same as previously, syncing every frame. 

**Before:**
| Game FPS | Specified Send Interval (Hz) | Actual Send Interval (Hz) | Interval Error % |
| --- | --- | --- | --- |
| ~160 | 60 | ~54 | 10% |
| 60 | 60 | ~40 | 33% |
| 60 | 30 | ~24 | 20% |

**After:**
| Game FPS | Specified Send Interval (Hz) | Actual Send Interval (Hz) | Interval Error % |
| --- | --- | --- | --- |
| ~160 | 60 | ~59.9 | 0.1% |
| 60 | 60 | ~59.8 | 0.3% |
| 60 | 30 | ~30 | 0.0% |