### PR TITLE
Room Manager allow join in progress

### DIFF
--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -341,6 +341,8 @@ namespace Mirror
                 newRoomGameObject = Instantiate(roomPlayerPrefab.gameObject, Vector3.zero, Quaternion.identity);
 
             NetworkServer.AddPlayerForConnection(conn, newRoomGameObject);
+            roomSlots.Add(newRoomGameObject.GetComponent<NetworkRoomPlayer>());
+            RecalculateRoomPlayerIndices();
 
             if (!IsSceneActive(RoomScene))
             {

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -51,10 +51,8 @@ namespace Mirror
                 if (room.dontDestroyOnLoad)
                     DontDestroyOnLoad(gameObject);
 
-                room.roomSlots.Add(this);
-
-                if (NetworkServer.active)
-                    room.RecalculateRoomPlayerIndices();
+                if (!isServer)
+                    room.roomSlots.Add(this);
 
                 if (NetworkClient.active)
                     room.CallOnClientEnterRoom();


### PR DESCRIPTION
Video demonstration. **https://www.youtube.com/watch?v=gTp6rODMnXU**
Shows Rooms working like they previously worked if AllowJoinGameInProgress is false
then shows Join in progress working when set to true

- Add AllowJoinGameInProgress, default to false
- Add OnRoomServerPlayerJoinedInProgress virtual method
- Recalculate room indices in the manager rather than the room player so it calculates accurately if a player joins in progress.