### PR TITLE
Added NetworkBehaviour OnEnableClient() & OnDisableClient()

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -47,6 +47,11 @@ namespace Mirror
         /// <summary>True on client if that component has been assigned to the client. E.g. player, pets, henchmen.</summary>
         public bool hasAuthority => netIdentity.hasAuthority;
 
+        /// <summary>True on client or host if the object is enabled</summary>
+        // note: can be used if the client is trying to access this NetworkBehaviour which may not be visible
+        //     (or Destroyed depending on the spawn handling) to prevent exceptions.
+        public bool isEnabled => netIdentity.isEnabled;
+
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId => netIdentity.netId;
 
@@ -1078,5 +1083,11 @@ namespace Mirror
 
         /// <summary>Stop event, only called for objects the client has authority over.</summary>
         public virtual void OnStopAuthority() {}
+
+        /// <summary>Like OnEnable(), called on client and host - will also be called if the aoi shows this object</summary>
+        public virtual void OnEnableClient() { }
+
+        /// <summary>Like OnDisable(), called on client and host - will also be called if the aoi hides this object</summary>
+        public virtual void OnDisableClient() { }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -50,7 +50,10 @@ namespace Mirror
         /// <summary>True on client or host if the object is enabled</summary>
         // note: can be used if the client is trying to access this NetworkBehaviour which may not be visible
         //     (or Destroyed depending on the spawn handling) to prevent exceptions.
-        public bool isEnabled => netIdentity.isEnabled;
+        public bool isClientEnabled => netIdentity.isClientEnabled;
+        
+        /// <summary>True on server or host if the object is enabled (Visible by atleast 1 Client or the host)</summary>
+        public bool isServerEnabled => netIdentity.isServerEnabled;
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId => netIdentity.netId;
@@ -1083,6 +1086,12 @@ namespace Mirror
 
         /// <summary>Stop event, only called for objects the client has authority over.</summary>
         public virtual void OnStopAuthority() {}
+
+        /// <summary>Like OnEnable(), called on server and host - will be called if the object becomes visible to atleast 1 client and was hidden (Disabled) before</summary>
+        public virtual void OnEnableServer() { }
+
+        /// <summary>Like OnEnable(), called on server and host - will be called if the object gets hidden and no one can see it anymore or if the object gets destroyed and the object is visible to atleast 1 client</summary>
+        public virtual void OnDisableServer() { }
 
         /// <summary>Like OnEnable(), called on client and host - will also be called if the aoi shows this object</summary>
         public virtual void OnEnableClient() { }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -1044,6 +1044,8 @@ namespace Mirror
                 identity.OnStartClient();
                 CheckForLocalPlayer(identity);
             }
+
+            identity.OnEnableClient();
         }
 
         // Finds Existing Object with NetId or spawns a new one using AssetId or sceneId
@@ -1245,6 +1247,8 @@ namespace Mirror
             {
                 if (aoi != null)
                     aoi.SetHostVisibility(localObject, false);
+
+                localObject.OnDisableClient();
             }
         }
 
@@ -1268,6 +1272,7 @@ namespace Mirror
                     aoi.SetHostVisibility(localObject, true);
 
                 CheckForLocalPlayer(localObject);
+                localObject.OnEnableClient();
             }
         }
 
@@ -1372,6 +1377,8 @@ namespace Mirror
                     localObject.OnStopLocalPlayer();
 
                 localObject.OnStopClient();
+
+                localObject.OnDisableClient();
 
                 // custom unspawn handler for this prefab? (for prefab pools etc.)
                 if (InvokeUnSpawnHandler(localObject.assetId, localObject.gameObject))

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1338,6 +1338,12 @@ namespace Mirror
 
             // send object destroy message to all observers, clear observers
             SendToObservers(identity, new ObjectDestroyMessage{netId = identity.netId});
+
+            if(identity.observers.Count > 0)
+            {
+                identity.OnDisableServer();
+            }
+
             identity.ClearObservers();
 
             // in host mode, call OnStopClient/OnStopLocalPlayer manually
@@ -1507,6 +1513,14 @@ namespace Mirror
                 {
                     if (conn != null && conn.isReady)
                         identity.observers.Add(conn.connectionId, conn);
+                }
+
+                if(newObservers.Count > 0)
+                {
+                    identity.OnEnableServer();
+                } else
+                {
+                    identity.OnDisableServer();
                 }
             }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -1331,6 +1331,11 @@ namespace Mirror
 
             identity.connectionToClient?.RemoveOwnedObject(identity);
 
+            if (NetworkClient.active && localClientActive)
+            {
+                identity.OnDisableClient();
+            }
+
             // send object destroy message to all observers, clear observers
             SendToObservers(identity, new ObjectDestroyMessage{netId = identity.netId});
             identity.ClearObservers();


### PR DESCRIPTION
This PR adds an simple **OnEnableClient()** and an **OnDisableClient()** method for the **NetworkBehaviour**.
Will be called if the **NetworkBehaviour** gets "visible" or "hidden" on the client or host.

If an **InterestManagement** is used, this callbacks will also be called if the **NetworkBehaviour** gets visible or hidden on the client/host.

**OnDisableClient()** will also be called when the object gets destroyed on the server and is visible to an client or the host