### PR TITLE
Added Weaver Compatibility with HashSet<T>

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -249,6 +249,19 @@ namespace Mirror
             return result;
         }
 
+        public static HashSet<T> ReadHashSet<T>(this NetworkReader reader)
+        {
+            int length = reader.ReadInt();
+            if (length < 0)
+                return null;
+            HashSet<T> result = new HashSet<T>(length);
+            for (int i = 0; i < length; i++)
+            {
+                result.Add(reader.Read<T>());
+            }
+            return result;
+        }
+
         public static T[] ReadArray<T>(this NetworkReader reader)
         {
             int length = reader.ReadInt();

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -293,6 +293,19 @@ namespace Mirror
                 writer.Write(array[i]);
         }
 
+        public static void WriteHashSet<T>(this NetworkWriter writer, HashSet<T> hashSet)
+        {
+            if (hashSet is null)
+            {
+                writer.WriteInt(-1);
+                return;
+            }
+            writer.WriteInt(hashSet.Count);
+            foreach (T item in hashSet)
+                writer.Write(item);
+        }
+
+
         public static void WriteUri(this NetworkWriter writer, Uri uri)
         {
             writer.WriteString(uri?.ToString());

--- a/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkWriterTest.cs
@@ -1317,6 +1317,28 @@ namespace Mirror.Tests
             Assert.That(readList, Is.Null);
         }
 
+        public void TestHashSet()
+        {
+            HashSet<int> original = new HashSet<int>() { 1, 2, 3, 4, 5 };
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write(original);
+
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            HashSet<int> readHashSet = reader.Read<HashSet<int>>();
+            Assert.That(readHashSet, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void TestNullHashSet()
+        {
+            NetworkWriter writer = new NetworkWriter();
+            writer.Write<HashSet<int>>(null);
+
+            NetworkReader reader = new NetworkReader(writer.ToArray());
+            HashSet<int> readHashSet = reader.Read<HashSet<int>>();
+            Assert.That(readHashSet, Is.Null);
+        }
+
 
         const int testArraySize = 4;
         [Test]


### PR DESCRIPTION
Added functionality for HashSet's to be automatically serialized in the same way Array's and List's are.