### PR TITLE
fix: #3302 StartHost: user callbacks OnStartServer/OnStartHost aren't invoked until everything was set up in FinishStartHost.

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -439,21 +439,6 @@ namespace Mirror
             // setup server first
             SetupServer();
 
-            // call OnStartServer AFTER Listen, so that NetworkServer.active is
-            // true and we can call NetworkServer.Spawn in OnStartServer
-            // overrides.
-            // (useful for loading & spawning stuff from database etc.)
-            //
-            // note: there is no risk of someone connecting after Listen() and
-            //       before OnStartServer() because this all runs in one thread
-            //       and we don't start processing connects until Update.
-            OnStartServer();
-
-            // call OnStartHost AFTER SetupServer. this way we can use
-            // NetworkServer.Spawn etc. in there too. just like OnStartServer
-            // is called after the server is actually properly started.
-            OnStartHost();
-
             // scene change needed? then change scene and spawn afterwards.
             // => BEFORE host client connects. if client auth succeeds then the
             //    server tells it to load 'onlineScene'. we can't do that if
@@ -509,6 +494,21 @@ namespace Mirror
             //
             // TODO call this after spawnobjects and worry about the syncvar hook fix later?
             NetworkClient.ConnectHost();
+
+            // invoke user callbacks AFTER ConnectHost has set .activeHost.
+            // this way initialization can properly handle host mode.
+            //
+            // fixes: https://github.com/MirrorNetworking/Mirror/issues/3302
+            // where [SyncVar] hooks wouldn't be called for objects spawned in
+            // NetworkManager.OnStartServer, because .activeHost was still false.
+            //
+            // TODO is there a risk of someone connecting between Listen() and FinishStartHost()?
+            OnStartServer();
+
+            // call OnStartHost AFTER SetupServer. this way we can use
+            // NetworkServer.Spawn etc. in there too. just like OnStartServer
+            // is called after the server is actually properly started.
+            OnStartHost();
 
             // server scene was loaded. now spawn all the objects
             NetworkServer.SpawnObjects();


### PR DESCRIPTION
TODO
- try in all examples
- try in my assets
- can someone connect between starthost() and finishhost(): need to only process connects after finishhost