### PR TITLE
Add Delegates for Client Connect and Disconnect

### DIFF
--- a/Assets/Mirror/Core/NetworkManagerDelegates.cs
+++ b/Assets/Mirror/Core/NetworkManagerDelegates.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror
+{
+	public class NetworkManagerDelegates : NetworkManager
+	{
+		public delegate void OnClientConnectDelegate();
+		public delegate void OnClientDisconnectDelegate();
+
+		public static OnClientConnectDelegate onClientConnectDelegate;
+		public static OnClientDisconnectDelegate onClientDisconnectDelegate;
+
+		public override void OnClientConnect()
+		{
+			base.OnClientConnect();
+
+			onClientConnectDelegate?.Invoke();
+		}
+
+		public override void OnClientDisconnect()
+		{
+			base.OnClientDisconnect();
+
+			onClientDisconnectDelegate?.Invoke();
+		}
+	}
+}


### PR DESCRIPTION
I know Mirror allows a subclass of NetworkManager to override a few methods to get notifications. But in order to easily decouple the UI that I am using from the games subclass of NetworkManager I want to be able to register for callbacks rather than relying on a single callback.

Thus the introduction of delegates.

This basically allows me, as an example, to separate NetworkManagerPong from my Unity UI and have my Unity UI updated based on client connection and disconnection callbacks rather than polling in the update method.

To make the code cleaner for me I added the delegates in a NetworkManagerDelegates implementation and then instead of my game overriding NetworkManager, it overrides NetworkManagerDelegates.

To be clear instead of having NetworkManagePong override NetworkManager I changed it it to override this new NetworkManagerDelegates. And then my UnityUI adds itself to the delegate list so that it is independently notified when the overridden methods are invoked.

It, perhaps, makes more sense for to integrate, at some point in time, Delegates directly into the NetworkManager but I leave all of that up to you.

However you decide to do it, there should be an elegant way to have multiple objects that are interested in NetworkManager callback receive them without the need to so tightly couple things and depend on a single callback.