### PR TITLE
fix: #2240 #3324 NetworkIdentity.OnDestroy removes from spawned if not removed yet. prevents null entries in .spawned.

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -641,7 +641,7 @@ namespace Mirror
                     NetworkClient.connection.owned.Remove(this);
 
                 // if an identity is still in .spawned, remove it too.
-                // fixes: https://github.com/vis2k/Mirror/pull/2240
+                // fixes: https://github.com/MirrorNetworking/Mirror/issues/3324
                 NetworkClient.spawned.Remove(netId);
             }
         }

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -635,10 +635,14 @@ namespace Mirror
                 // ServerChangeScene doesn't send destroy messages.
                 // some identities may persist in DDOL.
                 // some are destroyed by scene change.
-                // if an identity is still in .owned, remove it.
+                // if an identity is still in .owned remove it.
                 // fixes: https://github.com/MirrorNetworking/Mirror/issues/3308
                 if (NetworkClient.connection != null)
                     NetworkClient.connection.owned.Remove(this);
+
+                // if an identity is still in .spawned, remove it too.
+                // fixes: https://github.com/vis2k/Mirror/pull/2240
+                NetworkClient.spawned.Remove(netId);
             }
         }
 


### PR DESCRIPTION
Fixes: #3324 