### PR TITLE
fix: #3334 NetworkClient DestroyAllClientObjects Before ClearSpawners

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1613,13 +1613,13 @@ namespace Mirror
         {
             //Debug.Log("Shutting down client.");
 
+            // calls spawned.Clear() if no exception occurs
+            DestroyAllClientObjects();
+
             // calls prefabs.Clear();
             // calls spawnHandlers.Clear();
             // calls unspawnHandlers.Clear();
             ClearSpawners();
-
-            // calls spawned.Clear() if no exception occurs
-            DestroyAllClientObjects();
 
             spawned.Clear();
             connection?.owned.Clear();

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1613,7 +1613,8 @@ namespace Mirror
         {
             //Debug.Log("Shutting down client.");
 
-            // calls spawned.Clear() if no exception occurs
+            // objects need to be destroyed before spawners are cleared
+            // fixes: https://github.com/MirrorNetworking/Mirror/issues/3334
             DestroyAllClientObjects();
 
             // calls prefabs.Clear();


### PR DESCRIPTION
- DestroyAllClientObjects needs to be able to call Unspawn handlers
- Fixes: #3334 