### PR TITLE
fix: #3326 NetworkIdentity doesn't reset SyncObjects anymore

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1255,6 +1255,10 @@ namespace Mirror
         // we can't destroy them (they are always in the scene).
         // instead we disable them and call Reset().
         //
+        // Do not call ResetSyncObjects from Reset
+        // - Unspawned objects need to retain their list contents
+        // - They may be respawned, especially players, but others as well.
+        //
         // OLD COMMENT:
         // Marks the identity for future reset, this is because we cant reset
         // the identity during destroy as people might want to be able to read
@@ -1262,9 +1266,6 @@ namespace Mirror
         // after OnDestroy is called.
         internal void Reset()
         {
-            // make sure to call this before networkBehavioursCache is cleared below
-            ResetSyncObjects();
-
             hasSpawned = false;
             clientStarted = false;
             isClient = false;
@@ -1354,21 +1355,6 @@ namespace Mirror
                 conn.RemoveFromObserving(this, true);
             }
             observers.Clear();
-        }
-
-        void ResetSyncObjects()
-        {
-            // ResetSyncObjects is called by Reset, which is called by Unity.
-            // AddComponent() calls Reset().
-            // AddComponent() is called before Awake().
-            // so NetworkBehaviours may not be initialized yet.
-            if (NetworkBehaviours == null)
-                return;
-
-            foreach (NetworkBehaviour comp in NetworkBehaviours)
-            {
-                comp.ResetSyncObjects();
-            }
         }
     }
 }

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1255,7 +1255,7 @@ namespace Mirror
         // we can't destroy them (they are always in the scene).
         // instead we disable them and call Reset().
         //
-        // Do not call ResetSyncObjects from Reset
+        // Do not reset SyncObjects from Reset
         // - Unspawned objects need to retain their list contents
         // - They may be respawned, especially players, but others as well.
         //


### PR DESCRIPTION
Fixes: #3326 

- All callers to Reset are either unspawning (disabling) the object or have run a custom UnSpawnHandler
- Sync collections should retain their data in any case because the object may get respawned
- When it is respawned, OnDeserializeAll clears the internal collection and changes lists before adding back the entire payload.
- Users can always call the public Reset on the SyncObject themselves if they want it wiped.