### PR TITLE
fix: #3330 #2422 Mirror now ignores objects which inactive parents

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1230,7 +1230,15 @@ namespace Mirror
             if (!active)
                 return false;
 
-            NetworkIdentity[] identities = Resources.FindObjectsOfTypeAll<NetworkIdentity>();
+            // find all NetworkIdentities in the scene.
+            // all of them are disabled because of NetworkScenePostProcess.
+            // however, ignore identities under disabled parent objects.
+            // users would put them under disabled parents to 'deactivate' them.
+            // those should not be used by Mirror at all.
+            // fixes: https://github.com/MirrorNetworking/Mirror/issues/3330
+            IEnumerable<NetworkIdentity> identities = Resources.FindObjectsOfTypeAll<NetworkIdentity>()
+                .Where(identity => identity.transform.parent == null ||
+                                   identity.transform.parent.gameObject.activeInHierarchy);
 
             // first pass: activate all scene objects
             foreach (NetworkIdentity identity in identities)

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1051,6 +1051,15 @@ namespace Mirror
             // internally sends a spawn message for each one to the connection.
             foreach (NetworkIdentity identity in spawned.Values)
             {
+                // show a warning in case of unexpected null entries.
+                // keep spawning the other entries though.
+                // https://github.com/MirrorNetworking/Mirror/issues/3330
+                if (identity == null)
+                {
+                    Debug.LogWarning("SpawnObserversForConnection: skipping null entry in spawned. This should not happen.");
+                    continue;
+                }
+
                 // try with far away ones in ummorpg!
                 if (identity.gameObject.activeSelf) //TODO this is different
                 {


### PR DESCRIPTION
merge, not squash