### PR TITLE
fix: #3351 - Reset Statics in NS, NC, and NC_TimeInterpolation

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1650,6 +1650,7 @@ namespace Mirror
             ready = false;
             isSpawnFinished = false;
             isLoadingScene = false;
+            lastSendTime = 0;
 
             unbatcher = new Unbatcher();
 

--- a/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
+++ b/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
@@ -93,8 +93,10 @@ namespace Mirror
         // initialization called from Awake
         static void InitTimeInterpolation()
         {
-            // reset timeline & snapshots from last session (if any)
+            // reset timeline, localTimescale, bufferTimeMultiplier & snapshots from last session (if any)
             localTimeline = 0;
+            localTimescale = 1;
+            bufferTimeMultiplier = 2;
             snapshots.Clear();
 
             // initialize EMA with 'emaDuration' seconds worth of history.

--- a/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
+++ b/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
@@ -93,10 +93,11 @@ namespace Mirror
         // initialization called from Awake
         static void InitTimeInterpolation()
         {
-            // reset timeline, localTimescale, bufferTimeMultiplier & snapshots from last session (if any)
+            // reset timeline, localTimescale & snapshots from last session (if any)
+            // Don't reset bufferTimeMultiplier here - whatever their network condition
+            // was when they disconnected, it won't have changed on immediate reconnect.
             localTimeline = 0;
             localTimescale = 1;
-            bufferTimeMultiplier = 2;
             snapshots.Clear();
 
             // initialize EMA with 'emaDuration' seconds worth of history.

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -183,6 +183,7 @@ namespace Mirror
             active = false;
             isLoadingScene = false;
             lastSendTime = 0;
+            actualTickRate = 0;
 
             localConnection = null;
 


### PR DESCRIPTION
Fixes #3351 