### PR TITLE
Application.isFocused check on tanks Update input.

### DIFF
--- a/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
+++ b/Assets/Mirror/Examples/Tanks/Scripts/Tank.cs
@@ -27,6 +27,9 @@ namespace Mirror.Examples.Tanks
             // always update health bar.
             // (SyncVar hook would only update on clients, not on server)
             healthBar.text = new string('-', health);
+            
+            // take input from focused window only
+            if(!Application.isFocused) return; 
 
             // movement for local player
             if (isLocalPlayer)


### PR DESCRIPTION
To prevent multiple editors/builds on same PC effecting all players tanks. A few have been needing this, so nice to slip it into Mirror code somewhere for people to learn/reference from. Kudos to Zankaster and the others in Discord.