### PR TITLE
fix: #2623 NetworkServer.SetClientReady returns if already ready. fixes clients spamming ReadyMessage to force observer rebuilds etc. [imer]

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1034,6 +1034,11 @@ namespace Mirror
         {
             // Debug.Log($"SetClientReadyInternal for conn:{conn}");
 
+            // only if not already ready yet.
+            // prevents clients spamming ReadyMessage to force observer rebuilds.
+            // fixes: https://github.com/MirrorNetworking/Mirror/issues/2623
+            if (conn.isReady) return;
+
             // set ready
             conn.isReady = true;
 


### PR DESCRIPTION
WIP: see isready_bug_repro. this currently breaks OnStartClient etc. callbacks in remote clients