### PR TITLE
fix: Weaver doesn't NRE on generic array

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -16,7 +16,7 @@ namespace Mirror.Weaver
 
             foreach (FieldDefinition fd in td.Fields)
             {
-                if (fd.FieldType.IsGenericParameter)
+                if (fd.FieldType.IsGenericParameter || fd.ContainsGenericParameter)
                 {
                     // can't call .Resolve on generic ones
                     continue;

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverNetworkBehaviourTests_IsValid/NetworkBehaviourGeneric.cs
@@ -5,6 +5,7 @@ namespace WeaverNetworkBehaviourTests.NetworkBehaviourGeneric
     class NetworkBehaviourGeneric<T> : NetworkBehaviour
     {
         public T param;
+        public T[] paramArray;
         public readonly SyncList<T> syncList = new SyncList<T>();
     }
 


### PR DESCRIPTION
T[] would cause a NRE:

(0,0): error ----------------------------------------------
(0,0): error Exception :System.NullReferenceException: Object reference not set to an instance of an object.
(0,0): error    at Mirror.Weaver.Extensions.IsDerivedFrom(TypeReference tr, Type baseClass) in Mirror\Editor\Weaver\Extensions.cs:line 21
(0,0): error    at Mirror.Weaver.Extensions.IsDerivedFrom[T](TypeReference tr) in Mirror\Editor\Weaver\Extensions.cs:line 17
(0,0): error    at Mirror.Weaver.SyncObjectProcessor.FindSyncObjectsFields(Writers writers, Readers readers, Logger Log, TypeDefinition td, Boolean& WeavingFailed) in Mirror\Editor\Weaver\Processors\SyncObjectProcessor.cs:line 25
(0,0): error    at Mirror.Weaver.NetworkBehaviourProcessor.Process(Boolean& WeavingFailed) in Mirror\Editor\Weaver\Processors\NetworkBehaviourProcessor.cs:line 76
(0,0): error    at Mirror.Weaver.Weaver.WeaveNetworkBehavior(TypeDefinition td) in Mirror\Editor\Weaver\Weaver.cs:line 109
(0,0): error    at Mirror.Weaver.Weaver.WeaveModule(ModuleDefinition moduleDefinition) in Mirror\Editor\Weaver\Weaver.cs:line 125
(0,0): error    at Mirror.Weaver.Weaver.Weave(AssemblyDefinition assembly, IAssemblyResolver resolver, Boolean& modified) in Mirror\Editor\Weaver\Weaver.cs:line 208
(0,0): error ----------------------------------------------