### PR TITLE
feat: Read / Write DateTime

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -336,5 +336,10 @@ namespace Mirror
             // otherwise create a valid sprite
             return Sprite.Create(texture, reader.ReadRect(), reader.ReadVector2());
         }
+
+        public static DateTime ReadDateTime(this NetworkReader reader)
+        {
+            return DateTime.FromOADate(reader.ReadDouble());
+        }
     }
 }

--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -341,5 +341,7 @@ namespace Mirror
         {
             return DateTime.FromOADate(reader.ReadDouble());
         }
+
+        public static DateTime? ReadDateTimeNullable(this NetworkReader reader) => reader.ReadBool() ? ReadDateTime(reader) : default(DateTime?);
     }
 }

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -359,6 +360,13 @@ namespace Mirror
         public static void WriteDateTime(this NetworkWriter writer, DateTime dateTime)
         {
             writer.WriteDouble(dateTime.ToOADate());
+        }
+
+        public static void WriteDateTimeNullable(this NetworkWriter writer, DateTime? dateTime)
+        {
+            writer.WriteBool(dateTime.HasValue);
+            if (dateTime.HasValue)
+                writer.WriteDouble(dateTime.Value.ToOADate());
         }
     }
 }

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -355,5 +355,10 @@ namespace Mirror
             writer.WriteRect(sprite.rect);
             writer.WriteVector2(sprite.pivot);
         }
+
+        public static void WriteDateTime(this NetworkWriter writer, DateTime dateTime)
+        {
+            writer.WriteDouble(dateTime.ToOADate());
+        }
     }
 }

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -1,4 +1,3 @@
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
- no UTC conversion...users can do that on their own if they want / need to.
- Nullable support included
- WriteDouble and ReadDouble already have unit tests.

DateTime is a public struct but has no public fields (all properties) so no error is thrown if users try to use it in SyncVar / Cmd / Rpc / NetMsg, but no value is put on the wire and SyncVar hooks don't fire because the client determines no actual value change.