### PR TITLE
fix: NetworkWriter - Change MaxStringLength to ushort.MaxValue

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -64,12 +64,13 @@ namespace Mirror
             if (size == 0)
                 return null;
 
-            int realSize = size - 1;
+            ushort realSize = (ushort)(size - 1);
 
             // make sure it's within limits to avoid allocation attacks etc.
+            // using >= to ensure 65535 fails and throws because we'll be adding +1 to written below.
             if (realSize >= NetworkWriter.MaxStringLength)
             {
-                throw new EndOfStreamException($"ReadString too long: {realSize}. Limit is: {NetworkWriter.MaxStringLength}");
+                throw new EndOfStreamException($"NetworkReader.ReadString - Value too long: {realSize} bytes. Limit is: {NetworkWriter.MaxStringLength - 1} bytes");
             }
 
             ArraySegment<byte> data = reader.ReadBytesSegment(realSize);

--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -67,11 +67,8 @@ namespace Mirror
             ushort realSize = (ushort)(size - 1);
 
             // make sure it's within limits to avoid allocation attacks etc.
-            // using >= to ensure 65535 fails and throws because we'll be adding +1 to written below.
-            if (realSize >= NetworkWriter.MaxStringLength)
-            {
-                throw new EndOfStreamException($"NetworkReader.ReadString - Value too long: {realSize} bytes. Limit is: {NetworkWriter.MaxStringLength - 1} bytes");
-            }
+            if (realSize > NetworkWriter.MaxStringLength)
+                throw new EndOfStreamException($"NetworkReader.ReadString - Value too long: {realSize} bytes. Limit is: {NetworkWriter.MaxStringLength} bytes");
 
             ArraySegment<byte> data = reader.ReadBytesSegment(realSize);
 

--- a/Assets/Mirror/Core/NetworkWriter.cs
+++ b/Assets/Mirror/Core/NetworkWriter.cs
@@ -9,6 +9,7 @@ namespace Mirror
     /// <summary>Network Writer for most simple types like floats, ints, buffers, structs, etc. Use NetworkWriterPool.GetReader() to avoid allocations.</summary>
     public class NetworkWriter
     {
+        // the limit of ushort is so we can write string size prefix as only 2 bytes.
         public const ushort MaxStringLength = ushort.MaxValue;
         public const int DefaultCapacity = 1500;
 

--- a/Assets/Mirror/Core/NetworkWriter.cs
+++ b/Assets/Mirror/Core/NetworkWriter.cs
@@ -9,7 +9,7 @@ namespace Mirror
     /// <summary>Network Writer for most simple types like floats, ints, buffers, structs, etc. Use NetworkWriterPool.GetReader() to avoid allocations.</summary>
     public class NetworkWriter
     {
-        public const int MaxStringLength = 1024 * 32;
+        public const ushort MaxStringLength = ushort.MaxValue;
         public const int DefaultCapacity = 1500;
 
         // create writer immediately with it's own buffer so no one can mess with it and so that we can resize it.

--- a/Assets/Mirror/Core/NetworkWriter.cs
+++ b/Assets/Mirror/Core/NetworkWriter.cs
@@ -10,7 +10,8 @@ namespace Mirror
     public class NetworkWriter
     {
         // the limit of ushort is so we can write string size prefix as only 2 bytes.
-        public const ushort MaxStringLength = ushort.MaxValue;
+        // -1 so we can still encode 'null' into it too.
+        public const ushort MaxStringLength = ushort.MaxValue - 1;
         public const int DefaultCapacity = 1500;
 
         // create writer immediately with it's own buffer so no one can mess with it and so that we can resize it.

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -90,8 +90,9 @@ namespace Mirror
             int written = writer.encoding.GetBytes(value, 0, value.Length, writer.buffer, writer.Position + 2);
 
             // check if within max size
+            // using >= to ensure 65535 fails and throws because we'll be adding +1 to written below.
             if (written >= NetworkWriter.MaxStringLength)
-                throw new IndexOutOfRangeException($"NetworkWriter.Write(string) too long: {written}. Limit: {NetworkWriter.MaxStringLength}");
+                throw new IndexOutOfRangeException($"NetworkWriter.WriteString - Value too long: {written} bytes. Limit: {NetworkWriter.MaxStringLength - 1} bytes");
 
             // .Position is unchanged, so fill in the size header now.
             // we already ensured that max size fits into ushort.max-1.

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -90,9 +90,8 @@ namespace Mirror
             int written = writer.encoding.GetBytes(value, 0, value.Length, writer.buffer, writer.Position + 2);
 
             // check if within max size
-            // using >= to ensure 65535 fails and throws because we'll be adding +1 to written below.
-            if (written >= NetworkWriter.MaxStringLength)
-                throw new IndexOutOfRangeException($"NetworkWriter.WriteString - Value too long: {written} bytes. Limit: {NetworkWriter.MaxStringLength - 1} bytes");
+            if (written > NetworkWriter.MaxStringLength)
+                throw new IndexOutOfRangeException($"NetworkWriter.WriteString - Value too long: {written} bytes. Limit: {NetworkWriter.MaxStringLength} bytes");
 
             // .Position is unchanged, so fill in the size header now.
             // we already ensured that max size fits into ushort.max-1.


### PR DESCRIPTION
- local `realsize` in NetworkReaderExtensions.ReadString changed to ushort with proper casting
- Comments added to NetworkWriterExtensions
- Comments added to NetworkReaderExtensions
- Log output updated in both for consistency