### PR TITLE
perf: Cache Stable Hashes

### DIFF
--- a/Assets/Mirror/Core/Tools/Extensions.cs
+++ b/Assets/Mirror/Core/Tools/Extensions.cs
@@ -9,7 +9,11 @@ namespace Mirror
         public static string ToHexString(this ArraySegment<byte> segment) =>
             BitConverter.ToString(segment.Array, segment.Offset, segment.Count);
 
-        public static readonly Dictionary<string, int> StableHashes = new Dictionary<string, int>();
+        // GetStableHashCode is O(N).
+        // the longer the string, the more it needs to compute:
+        // https://github.com/MirrorNetworking/Mirror/pull/3377
+        // cache results for O(1) lookups.
+        static readonly Dictionary<string, int> StableHashes = new Dictionary<string, int>();
 
         [UnityEngine.RuntimeInitializeOnLoadMethod]
         public static void ResetStatics()

--- a/Assets/Mirror/Core/Tools/Extensions.cs
+++ b/Assets/Mirror/Core/Tools/Extensions.cs
@@ -9,15 +9,28 @@ namespace Mirror
         public static string ToHexString(this ArraySegment<byte> segment) =>
             BitConverter.ToString(segment.Array, segment.Offset, segment.Count);
 
+        public static readonly Dictionary<string, int> StableHashes = new Dictionary<string, int>();
+
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+        public static void ResetStatics()
+        {
+            StableHashes.Clear();
+        }
+
         // string.GetHashCode is not guaranteed to be the same on all machines, but
         // we need one that is the same on all machines. simple and stupid:
         public static int GetStableHashCode(this string text)
         {
+            if (StableHashes.TryGetValue(text, out int cachedHash))
+                return cachedHash;
+
             unchecked
             {
                 int hash = 23;
                 foreach (char c in text)
                     hash = hash * 31 + c;
+
+                StableHashes[text] = hash;
                 return hash;
             }
         }

--- a/Assets/Mirror/Core/Tools/Extensions.cs
+++ b/Assets/Mirror/Core/Tools/Extensions.cs
@@ -30,6 +30,7 @@ namespace Mirror
                 foreach (char c in text)
                     hash = hash * 31 + c;
 
+                //UnityEngine.Debug.Log($"Caching stable hash {(ushort)hash} for {text}");
                 StableHashes[text] = hash;
                 return hash;
             }


### PR DESCRIPTION
- Static dictionary of message hashes
- ResetStatics

BEFORE
![image](https://user-images.githubusercontent.com/9826063/218214982-b2b13e57-fd6a-4fab-9cc2-990bcaecd33b.png)

AFTER
![image](https://user-images.githubusercontent.com/9826063/218255170-f3e214cd-ab3f-45ca-87b7-5754bdb7b61f.png)

Debug output of the dictionary:
```
17570: System.Void Mirror.NetworkTransform::CmdClientToServerSync(System.Nullable`1<UnityEngine.Vector3>,System.Nullable`1<UnityEngine.Quaternion>,System.Nullable`1<UnityEngine.Vector3>)
11031: System.Void Mirror.NetworkTransform::RpcServerToClientSync(System.Nullable`1<UnityEngine.Vector3>,System.Nullable`1<UnityEngine.Quaternion>,System.Nullable`1<UnityEngine.Vector3>)
39853: System.Void Mirror.NetworkTransformBase::CmdTeleport(UnityEngine.Vector3)
30084: System.Void Mirror.NetworkTransformBase::CmdTeleport(UnityEngine.Vector3,UnityEngine.Quaternion)
 1762: System.Void Mirror.NetworkTransformBase::RpcTeleport(UnityEngine.Vector3)
16047: System.Void Mirror.NetworkTransformBase::RpcTeleport(UnityEngine.Vector3,UnityEngine.Quaternion)
54341: System.Void Mirror.NetworkTransformBase::RpcReset()
47217: System.Void Mirror.NetworkRoomPlayer::CmdChangeReadyState(System.Boolean)
```
