### PR TITLE
feature: NetworkTransform interpolation can be disabled

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -47,6 +47,8 @@ namespace Mirror
         public bool syncRotation = true;  // do not change at runtime!
         public bool syncScale    = false; // do not change at runtime! rare. off by default.
 
+        // interpolation is on by default, but can be disabled to jump to
+        // the destination immediately. some projects need this.
         [Header("Interpolation")]
         [Tooltip("Set to false to have a snap-like effect on position movement.")]
         public bool interpolatePosition = true;

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -42,10 +42,18 @@ namespace Mirror
         public readonly SortedList<double, TransformSnapshot> serverSnapshots = new SortedList<double, TransformSnapshot>();
 
         // selective sync //////////////////////////////////////////////////////
-        [Header("Selective Sync & Interpolation\nDon't change these at Runtime")]
+        [Header("Selective Sync\nDon't change these at Runtime")]
         public bool syncPosition = true;  // do not change at runtime!
         public bool syncRotation = true;  // do not change at runtime!
         public bool syncScale    = false; // do not change at runtime! rare. off by default.
+
+        [Header("Interpolation")]
+        [Tooltip("Set to false to have a snap-like effect on position movement.")]
+        public bool interpolatePosition = true;
+        [Tooltip("Set to false to have a snap-like effect on rotations.")]
+        public bool interpolateRotation = true;
+        [Tooltip("Set to false to remove scale smoothing. Example use-case: Instant flipping of sprites that use -X and +X for direction.")]
+        public bool interpolateScale = true;
 
         // debugging ///////////////////////////////////////////////////////////
         [Header("Debug")]
@@ -141,7 +149,7 @@ namespace Mirror
         //
         // NOTE: stuck detection is unnecessary here.
         //       we always set transform.position anyway, we can't get stuck.
-        protected virtual void Apply(TransformSnapshot interpolated)
+        protected virtual void Apply(TransformSnapshot interpolated, TransformSnapshot endGoal)
         {
             // local position/rotation for VR support
             //
@@ -153,6 +161,15 @@ namespace Mirror
             if (syncPosition) target.localPosition = interpolated.position;
             if (syncRotation) target.localRotation = interpolated.rotation;
             if (syncScale)    target.localScale = interpolated.scale;
+
+            if (syncPosition)
+                target.localPosition = interpolatePosition ? interpolated.position : endGoal.position;
+
+            if (syncRotation)
+                target.localRotation = interpolateRotation ? interpolated.rotation : endGoal.rotation;
+
+            if (syncScale)
+                target.localScale = interpolateScale ? interpolated.scale : endGoal.scale;
         }
 
         // client->server teleport to force position without interpolation.

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -160,9 +160,6 @@ namespace Mirror
             // -> we still interpolated
             // -> but simply don't apply it. if the user doesn't want to sync
             //    scale, then we should not touch scale etc.
-            if (syncPosition) target.localPosition = interpolated.position;
-            if (syncRotation) target.localRotation = interpolated.rotation;
-            if (syncScale)    target.localScale = interpolated.scale;
 
             if (syncPosition)
                 target.localPosition = interpolatePosition ? interpolated.position : endGoal.position;

--- a/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
@@ -82,7 +82,7 @@ namespace Mirror
 
                     // interpolate & apply
                     TransformSnapshot computed = TransformSnapshot.Interpolate(from, to, t);
-                    Apply(computed);
+                    Apply(computed, to);
                 }
             }
 
@@ -129,7 +129,7 @@ namespace Mirror
 
                     // interpolate & apply
                     TransformSnapshot computed = TransformSnapshot.Interpolate(from, to, t);
-                    Apply(computed);
+                    Apply(computed, to);
 
                 }
 

--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkTransform.cs
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkTransform.cs
@@ -144,7 +144,7 @@ namespace Mirror
 
                     // interpolate & apply
                     TransformSnapshot computed = TransformSnapshot.Interpolate(from, to, t);
-                    Apply(computed);
+                    Apply(computed, to);
                 }
             }
         }
@@ -235,7 +235,7 @@ namespace Mirror
 
                     // interpolate & apply
                     TransformSnapshot computed = TransformSnapshot.Interpolate(from, to, t);
-                    Apply(computed);
+                    Apply(computed, to);
                 }
             }
         }

--- a/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform2kTests.cs
@@ -11,7 +11,7 @@ namespace Mirror.Tests.NetworkTransform2k
     {
         public new TransformSnapshot Construct() => base.Construct();
         public new void Apply(TransformSnapshot interpolated) =>
-            base.Apply(interpolated);
+            base.Apply(interpolated, interpolated);
         public new void OnClientToServerSync(Vector3? position, Quaternion? rotation, Vector3? scale) =>
             base.OnClientToServerSync(position, rotation, scale);
         public new void OnServerToClientSync(Vector3? position, Quaternion? rotation, Vector3? scale) =>


### PR DESCRIPTION
Gives a snap-like effect to position, rotation and scaling.

Video
First half is interpolations off
Second half is interpolations on

(Note: SendRate was set from 30* to 5, for video, as it was too smooth at 30 to see interpolation off)
I dont know what to set in the NetworkTransform2kTests - base.Apply(interpolated, THIS->interpolated);

https://user-images.githubusercontent.com/57072365/218549286-83c03a3e-bc8a-4b86-9a75-d0c2516d8269.mp4



