### PR TITLE
feat: InterestManagementBase

### DIFF
--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -1,5 +1,6 @@
 // interest management component for custom solutions like
 // distance based, spatial hashing, raycast based, etc.
+// low level base class allows for low level spatial hashing etc., which is 3-5x faster.
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -1,0 +1,83 @@
+// interest management component for custom solutions like
+// distance based, spatial hashing, raycast based, etc.
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror
+{
+    [DisallowMultipleComponent]
+    [HelpURL("https://mirror-networking.gitbook.io/docs/guides/interest-management")]
+    public abstract class InterestManagementBase : MonoBehaviour
+    {
+        // Awake configures InterestManagementBase in NetworkServer/Client
+        // Do NOT check for active server or client here.
+        // Awake must always set the static aoi references.
+        // make sure to call base.Awake when overwriting!
+        protected virtual void Awake()
+        {
+            if (NetworkServer.aoi == null)
+            {
+                NetworkServer.aoi = this;
+            }
+            else Debug.LogError($"Only one InterestManagement component allowed. {NetworkServer.aoi.GetType()} has been set up already.");
+
+            if (NetworkClient.aoi == null)
+            {
+                NetworkClient.aoi = this;
+            }
+            else Debug.LogError($"Only one InterestManagement component allowed. {NetworkClient.aoi.GetType()} has been set up already.");
+        }
+
+        [ServerCallback]
+        public virtual void Reset() {}
+
+        // Callback used by the visibility system to determine if an observer
+        // (player) can see the NetworkIdentity. If this function returns true,
+        // the network connection will be added as an observer.
+        //   conn: Network connection of a player.
+        //   returns True if the player can see this object.
+        public abstract bool OnCheckObserver(NetworkIdentity identity, NetworkConnectionToClient newObserver);
+
+
+        // Callback used by the visibility system for objects on a host.
+        // Objects on a host (with a local client) cannot be disabled or
+        // destroyed when they are not visible to the local client. So this
+        // function is called to allow custom code to hide these objects. A
+        // typical implementation will disable renderer components on the
+        // object. This is only called on local clients on a host.
+        // => need the function in here and virtual so people can overwrite!
+        // => not everyone wants to hide renderers!
+        [ServerCallback]
+        public virtual void SetHostVisibility(NetworkIdentity identity, bool visible)
+        {
+            foreach (Renderer rend in identity.GetComponentsInChildren<Renderer>())
+                rend.enabled = visible;
+        }
+
+        /// <summary>Called on the server when a new networked object is spawned.</summary>
+        // (useful for 'only rebuild if changed' interest management algorithms)
+        [ServerCallback]
+        public virtual void OnSpawned(NetworkIdentity identity) {}
+
+        /// <summary>Called on the server when a networked object is destroyed.</summary>
+        // (useful for 'only rebuild if changed' interest management algorithms)
+        [ServerCallback]
+        public virtual void OnDestroyed(NetworkIdentity identity) {}
+
+        public abstract void Rebuild(NetworkIdentity identity, bool initialize);
+
+        /// <summary>Adds the specified connection to the observers of identity</summary>
+        protected void AddObserver(NetworkConnectionToClient connection, NetworkIdentity identity)
+        {
+            connection.AddToObserving(identity);
+            identity.observers.Add(connection.connectionId, connection);
+        }
+
+        /// <summary>Removes the specified connection from the observers of identity</summary>
+        protected void RemoveObserver(NetworkConnectionToClient connection, NetworkIdentity identity)
+        {
+            connection.RemoveFromObserving(identity, false);
+            identity.observers.Remove(connection.connectionId);
+        }
+    }
+}

--- a/Assets/Mirror/Core/InterestManagementBase.cs.meta
+++ b/Assets/Mirror/Core/InterestManagementBase.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 18bd2ffe65a444f3b13d59bdac7f2228
+timeCreated: 1676129329

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -115,7 +115,7 @@ namespace Mirror
 
         // interest management component (optional)
         // only needed for SetHostVisibility
-        public static InterestManagement aoi;
+        public static InterestManagementBase aoi;
 
         // scene loading
         public static bool isLoadingScene;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -68,7 +68,7 @@ namespace Mirror
 
         // interest management component (optional)
         // by default, everyone observes everyone
-        public static InterestManagement aoi;
+        public static InterestManagementBase aoi;
 
         // OnConnected / OnDisconnected used to be NetworkMessages that were
         // invoked. this introduced a bug where external clients could send


### PR DESCRIPTION
A low level interest management base class that allows more advanced interest management by bypassing the built-in HashSet checks
Full compatibility with existing interest management classes is preserved, this is technically a breaking change since NetworkServer.aoi/NetworkClient.aoi is a different type (but with same api), but that is the only breaking change I can think of

See previous PR #2764
See also https://github.com/vis2k/Mirror/pull/2581#issuecomment-780471482

