### PR TITLE
perf: Use static generic class to cache message id

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -471,7 +471,7 @@ namespace Mirror
         public static void RegisterHandler<T>(Action<T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             if (handlers.ContainsKey(msgType))
             {
                 Debug.LogWarning($"NetworkClient.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
@@ -490,7 +490,7 @@ namespace Mirror
         public static void ReplaceHandler<T>(Action<NetworkConnection, T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication);
         }
 
@@ -508,7 +508,7 @@ namespace Mirror
             where T : struct, NetworkMessage
         {
             // use int to minimize collisions
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             return handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -10,6 +10,12 @@ namespace Mirror
     // generic classes have separate static fields per type specification
     public static class NetworkMessageId<T> where T : struct, NetworkMessage
     {
+        // automated message id from type hash.
+        // platform independent via stable hashcode.
+        // => convenient so we don't need to track messageIds across projects
+        // => addons can work with each other without knowing their ids before
+        // => 2 bytes is enough to avoid collisions.
+        //    registering a messageId twice will log a warning anyway.
         public static readonly ushort Id = (ushort)(typeof(T).FullName.GetStableHashCode());
     }
 

--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -12,7 +12,7 @@ namespace Mirror
     {
         public static readonly ushort Id = (ushort)(typeof(T).FullName.GetStableHashCode());
     }
-    
+
     // message packing all in one place, instead of constructing headers in all
     // kinds of different places
     //
@@ -42,6 +42,8 @@ namespace Mirror
         // => 2 bytes is enough to avoid collisions.
         //    registering a messageId twice will log a warning anyway.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        // Deprecated 2023-02-15
+        [Obsolete("Use NetworkMessageId<T>.Id instead")]
         public static ushort GetId<T>() where T : struct, NetworkMessage =>
             NetworkMessageId<T>.Id;
 
@@ -52,7 +54,7 @@ namespace Mirror
         public static void Pack<T>(T message, NetworkWriter writer)
             where T : struct, NetworkMessage
         {
-            writer.WriteUShort(GetId<T>());
+            writer.WriteUShort(NetworkMessageId<T>.Id);
             writer.Write(message);
         }
 

--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -6,7 +6,7 @@ namespace Mirror
 {
 
     // for performance, we (ab)use c# generics to cache the message id in a static field
-    // this is significantly faster than doing a runtime Dictionary lookup
+    // this is significantly faster than doing the computation at runtime or looking up cached results via Dictionary
     // generic classes have separate static fields per type specification
     public static class NetworkMessageId<T> where T : struct, NetworkMessage
     {

--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -41,8 +41,8 @@ namespace Mirror
         // => addons can work with each other without knowing their ids before
         // => 2 bytes is enough to avoid collisions.
         //    registering a messageId twice will log a warning anyway.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         // Deprecated 2023-02-15
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [Obsolete("Use NetworkMessageId<T>.Id instead")]
         public static ushort GetId<T>() where T : struct, NetworkMessage =>
             NetworkMessageId<T>.Id;

--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -4,6 +4,15 @@ using UnityEngine;
 
 namespace Mirror
 {
+
+    // for performance, we (ab)use c# generics to cache the message id in a static field
+    // this is significantly faster than doing a runtime Dictionary lookup
+    // generic classes have separate static fields per type specification
+    public static class NetworkMessageId<T> where T : struct, NetworkMessage
+    {
+        public static readonly ushort Id = (ushort)(typeof(T).FullName.GetStableHashCode());
+    }
+    
     // message packing all in one place, instead of constructing headers in all
     // kinds of different places
     //
@@ -34,7 +43,7 @@ namespace Mirror
         //    registering a messageId twice will log a warning anyway.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort GetId<T>() where T : struct, NetworkMessage =>
-            (ushort)(typeof(T).FullName.GetStableHashCode());
+            NetworkMessageId<T>.Id;
 
         // pack message before sending
         // -> NetworkWriter passed as arg so that we can use .ToArraySegment

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -772,7 +772,7 @@ namespace Mirror
         public static void RegisterHandler<T>(Action<NetworkConnectionToClient, T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             if (handlers.ContainsKey(msgType))
             {
                 Debug.LogWarning($"NetworkServer.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
@@ -785,7 +785,7 @@ namespace Mirror
         public static void RegisterHandler<T>(Action<NetworkConnectionToClient, T, int> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             if (handlers.ContainsKey(msgType))
             {
                 Debug.LogWarning($"NetworkServer.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
@@ -804,7 +804,7 @@ namespace Mirror
         public static void ReplaceHandler<T>(Action<NetworkConnectionToClient, T> handler, bool requireAuthentication = true)
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication);
         }
 
@@ -812,7 +812,7 @@ namespace Mirror
         public static void UnregisterHandler<T>()
             where T : struct, NetworkMessage
         {
-            ushort msgType = NetworkMessages.GetId<T>();
+            ushort msgType = NetworkMessageId<T>.Id;
             handlers.Remove(msgType);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkMessagesTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkMessagesTest.cs
@@ -29,7 +29,7 @@ namespace Mirror.Tests
         {
             using (NetworkReaderPooled networkReader = NetworkReaderPool.Get(data))
             {
-                int msgType = NetworkMessages.GetId<T>();
+                int msgType = NetworkMessageId<T>.Id;
 
                 int id = networkReader.ReadUShort();
                 if (id != msgType)
@@ -46,7 +46,7 @@ namespace Mirror.Tests
         {
             // "Mirror.Tests.MessageTests.TestMessage"
             Debug.Log(typeof(TestMessage).FullName);
-            Assert.That(NetworkMessages.GetId<TestMessage>(), Is.EqualTo(0x8706));
+            Assert.That(NetworkMessageId<TestMessage>.Id, Is.EqualTo(0x8706));
         }
 
         [Test]


### PR DESCRIPTION
**MrG Note:** This obsoletes NetworkMessages.GetId, which forwards callers to the new NetworkMessageId static class and generic, so not a breaking change at this point.  Breaking change will come in 3 mos when the obsolete is removed.

Note we already use this technique for NetworkWriter (&reader), so should work across all platforms:
https://github.com/MirrorNetworking/Mirror/blob/59dc88c981b1612cbf62a2a4f739d6475e1bb338/Assets/Mirror/Core/NetworkWriter.cs#L245-L251

we can (ab)use c# generics to cache the message id in a static field
this is significantly faster than doing a runtime Dictionary lookup in my testing (16% thread cpu-> ~0.22% for 121 moving nts) 
![image](https://user-images.githubusercontent.com/1426904/218863016-36b2f011-b50c-4c99-936c-15dcc8ad323f.png)
vs 
![image](https://user-images.githubusercontent.com/1426904/218863033-084835c2-15c1-47af-bafb-3c5107cc0f56.png)
