### PR TITLE
perf: batcher no-dict lookup for (Un)Reliable

### DIFF
--- a/Assets/Mirror/Core/NetworkConnection.cs
+++ b/Assets/Mirror/Core/NetworkConnection.cs
@@ -44,6 +44,10 @@ namespace Mirror
         //            Works fine with NetworkIdentity pointers though.
         public readonly HashSet<NetworkIdentity> owned = new HashSet<NetworkIdentity>();
 
+        // define batchers for both channels explicitly.
+        // Mirror only ever uses reliable and unreliable.
+        // this is faster than a Dict<channel, batcher>:
+        // https://github.com/MirrorNetworking/Mirror/pull/3382
         protected Batcher reliableBatcher;
         protected Batcher unreliableBatcher;
         // batching from server to client & client to server.

--- a/Assets/Mirror/Core/NetworkConnection.cs
+++ b/Assets/Mirror/Core/NetworkConnection.cs
@@ -82,6 +82,15 @@ namespace Mirror
             connectionId = networkConnectionId;
         }
 
+        private Batcher CreateBatcher(int channelId)
+        {
+            // get max batch size for this channel
+            int threshold = Transport.active.GetBatchThreshold(channelId);
+
+            // create batcher
+            return new Batcher(threshold);
+        }
+
         protected Batcher GetBatchForChannelId(int channelId)
         {
             // having hard-coded lookups for the most common channels is unfortunately worth it, performance wise
@@ -90,11 +99,7 @@ namespace Mirror
             {
                 if (reliableBatcher == null)
                 {
-                    // get max batch size for this channel
-                    int threshold = Transport.active.GetBatchThreshold(channelId);
-
-                    // create batcher
-                    reliableBatcher = new Batcher(threshold);
+                    reliableBatcher = CreateBatcher(channelId);
                 }
                 return reliableBatcher;
             }
@@ -103,11 +108,7 @@ namespace Mirror
             {
                 if (unreliableBatcher == null)
                 {
-                    // get max batch size for this channel
-                    int threshold = Transport.active.GetBatchThreshold(channelId);
-
-                    // create batcher
-                    unreliableBatcher = new Batcher(threshold);
+                    unreliableBatcher = CreateBatcher(channelId);
                 }
                 return unreliableBatcher;
             }
@@ -116,12 +117,7 @@ namespace Mirror
             Batcher batch;
             if (!batches.TryGetValue(channelId, out batch))
             {
-                // get max batch size for this channel
-                int threshold = Transport.active.GetBatchThreshold(channelId);
-
-                // create batcher
-                batch = new Batcher(threshold);
-                batches[channelId] = batch;
+                batches[channelId] = batch = CreateBatcher(channelId);
             }
             return batch;
         }
@@ -231,7 +227,7 @@ namespace Mirror
             {
                 UpdateBatcher(Channels.Reliable, reliableBatcher);
             }
-            
+
             if (unreliableBatcher != null)
             {
                 UpdateBatcher(Channels.Unreliable, unreliableBatcher);


### PR DESCRIPTION
Dict lookup uses 6% in an il2cpp build for 121 nts, this ugly patch brings that down to 0.x%

I don't like this from a code perspective, so lets talk if there's a better way

Do people actually use channel ids that are big? We could do an array lookup instead with the channelId as index if they dont 
Or looping over a list to find the channel by id should be faster than using a Dict for 2 (or a handful) of values
Allowing more than the 2 default channels might be useful for some people, so I wouldnt advocate removing them outright

Bleh.