### PR TITLE
fix: #2680 Weaver: never use custom NB writers for SyncVars

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -443,7 +443,21 @@ namespace Mirror.Weaver
                 // this
                 worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldfld, syncVar);
-                MethodReference writeFunc = writers.GetWriteFunc(syncVar.FieldType, ref WeavingFailed);
+                MethodReference writeFunc;
+                // For NBs we always need to use the default NetworkBehaviour write func
+                // since the reader counter part uses that exact layout which is not easy to change
+                // without introducing more edge cases
+                // effectively this disallows custom NB-type writers/readers on SyncVars
+                // see: https://github.com/MirrorNetworking/Mirror/issues/2680
+                if (syncVar.FieldType.IsDerivedFrom<NetworkBehaviour>())
+                {
+                    writeFunc = writers.GetWriteFunc(weaverTypes.Import<NetworkBehaviour>(), ref WeavingFailed);
+                }
+                else
+                {
+                    writeFunc = writers.GetWriteFunc(syncVar.FieldType, ref WeavingFailed);
+                }
+
                 if (writeFunc != null)
                 {
                     worker.Emit(OpCodes.Call, writeFunc);
@@ -503,7 +517,21 @@ namespace Mirror.Weaver
                 worker.Emit(OpCodes.Ldarg_0);
                 worker.Emit(OpCodes.Ldfld, syncVar);
 
-                MethodReference writeFunc = writers.GetWriteFunc(syncVar.FieldType, ref WeavingFailed);
+                MethodReference writeFunc;
+                // For NBs we always need to use the default NetworkBehaviour write func
+                // since the reader counter part uses that exact layout which is not easy to change
+                // without introducing more edge cases
+                // effectively this disallows custom NB-type writers/readers on SyncVars
+                // see: https://github.com/MirrorNetworking/Mirror/issues/2680
+                if (syncVar.FieldType.IsDerivedFrom<NetworkBehaviour>())
+                {
+                    writeFunc = writers.GetWriteFunc(weaverTypes.Import<NetworkBehaviour>(), ref WeavingFailed);
+                }
+                else
+                {
+                    writeFunc = writers.GetWriteFunc(syncVar.FieldType, ref WeavingFailed);
+                }
+                
                 if (writeFunc != null)
                 {
                     worker.Emit(OpCodes.Call, writeFunc);


### PR DESCRIPTION
We always use a specific reader for NB syncvars, so if a custom defined writer handles data differently this leads to data mismatches.

Supporting custom readers for NB syncvars will just lead to too many edge cases and unexpected behaviour, so dont do it (see https://github.com/MirrorNetworking/Mirror/issues/2680#issuecomment-1435093212 for rationale).

Fixes #2680