### PR TITLE
breaking: Remove NetworkClient.serverIP

### DIFF
--- a/Assets/Mirror/Core/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Core/LocalConnectionToServer.cs
@@ -13,7 +13,9 @@ namespace Mirror
         // packet queue
         internal readonly Queue<NetworkWriterPooled> queue = new Queue<NetworkWriterPooled>();
 
-        public override string address => "localhost";
+        // Deprecated 2023-02-23
+        [Obsolete("Use LocalConnectionToClient.address instead.")]
+        public string address => "localhost";
 
         // see caller for comments on why we need this
         bool connectedEventPending;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -59,10 +59,6 @@ namespace Mirror
         // NetworkClient state
         internal static ConnectState connectState = ConnectState.None;
 
-        /// <summary>IP address of the connection to server.</summary>
-        // empty if the client has not connected yet.
-        public static string serverIp => connection.address;
-
         /// <summary>active is true while a client is connecting/connected either as standalone or as host client.</summary>
         // (= while the network is active)
         public static bool active => connectState == ConnectState.Connecting ||

--- a/Assets/Mirror/Core/NetworkConnection.cs
+++ b/Assets/Mirror/Core/NetworkConnection.cs
@@ -27,9 +27,6 @@ namespace Mirror
         // state.
         public bool isReady;
 
-        /// <summary>IP address of the connection. Can be useful for game master IP bans etc.</summary>
-        public abstract string address { get; }
-
         /// <summary>Last time a message was received for this connection. Includes system and user messages.</summary>
         public float lastMessageTime;
 

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -14,8 +14,7 @@ namespace Mirror
         readonly NetworkWriter reliableRpcs = new NetworkWriter();
         readonly NetworkWriter unreliableRpcs = new NetworkWriter();
 
-        public override string address =>
-            Transport.active.ServerGetClientAddress(connectionId);
+        public virtual string address => Transport.active.ServerGetClientAddress(connectionId);
 
         /// <summary>NetworkIdentities that this connection can see</summary>
         // TODO move to server's NetworkConnectionToClient?

--- a/Assets/Mirror/Core/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToServer.cs
@@ -5,8 +5,6 @@ namespace Mirror
 {
     public class NetworkConnectionToServer : NetworkConnection
     {
-        public override string address => "";
-
         // Send stage three: hand off to transport
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void SendToTransport(ArraySegment<byte> segment, int channelId = Channels.Reliable) =>

--- a/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
@@ -51,8 +51,6 @@ namespace Mirror.Tests
         [Test]
         public void ServerToClient()
         {
-            Assert.That(connectionToServer.address, Is.EqualTo("localhost"));
-
             bool invoked = false;
             void Handler(TestMessage message)
             {

--- a/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 
 namespace Mirror.Tests
@@ -11,13 +11,6 @@ namespace Mirror.Tests
             base.SetUp();
             // we need a server to connect to
             NetworkServer.Listen(10);
-        }
-
-        [Test]
-        public void ServerIp()
-        {
-            NetworkClient.ConnectHost();
-            Assert.That(NetworkClient.serverIp, Is.EqualTo("localhost"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
+++ b/Assets/Mirror/Tests/Editor/TargetRpcTest.cs
@@ -144,7 +144,6 @@ namespace Mirror.Tests.RemoteAttrributeTest
         }
         class FakeConnection : NetworkConnection
         {
-            public override string address => throw new NotImplementedException();
             public override void Disconnect() => throw new NotImplementedException();
             internal override void Send(ArraySegment<byte> segment, int channelId = 0) => throw new NotImplementedException();
             protected override void SendToTransport(ArraySegment<byte> segment, int channelId = Channels.Reliable) => throw new NotImplementedException();


### PR DESCRIPTION
- If we're never going to set it to anything, no reason to have it.
- Transport has no mechanism to return anything for it

Host client hardcodes `address` to "localhost" in both LocalConnectionToServer and LocalConnetionToClient, so obsolete the former telling users to use the latter if they aren't already.

Users can get the endpoint from NetworkManager or Discovery, as they must be doing now since those work and serverIp does not.