### PR TITLE
Shortened PingWindowSize to get a faster more accurate result.

### DIFF
--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -19,7 +19,7 @@ namespace Mirror
         public static float PingFrequency = 2;
 
         /// <summary>Average out the last few results from Ping</summary>
-        public static int PingWindowSize = 10;
+        public static int PingWindowSize = 6;
 
         static double lastPingTime;
 
@@ -74,7 +74,7 @@ namespace Mirror
         public static void ResetStatics()
         {
             PingFrequency = 2;
-            PingWindowSize = 10;
+            PingWindowSize = 6;
             lastPingTime = 0;
             _rtt = new ExponentialMovingAverage(PingWindowSize);
 #if !UNITY_2020_3_OR_NEWER

--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -19,7 +19,7 @@ namespace Mirror
         public static float PingFrequency = 2;
 
         /// <summary>Average out the last few results from Ping</summary>
-        public static int PingWindowSize = 6;
+        public static int PingWindowSize = 10;
 
         static double lastPingTime;
 
@@ -74,7 +74,7 @@ namespace Mirror
         public static void ResetStatics()
         {
             PingFrequency = 2;
-            PingWindowSize = 6;
+            PingWindowSize = 10;
             lastPingTime = 0;
             _rtt = new ExponentialMovingAverage(PingWindowSize);
 #if !UNITY_2020_3_OR_NEWER


### PR DESCRIPTION
Shortened PingWindowSize to get a faster more accurate result. It taking too long to calculate the average may look bad to users, choosing 6 gives us an average of 3 results, where as the previous 10, would wait for 5, it should be a slight visual improvement.