### PR TITLE
breaking: Removed old Unity 2018 / 2019_3 compiler defines

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -10,8 +10,8 @@ using UnityEditor;
 
 #if UNITY_2021_2_OR_NEWER
 using UnityEditor.SceneManagement;
-#elif UNITY_2018_3_OR_NEWER
-        using UnityEditor.Experimental.SceneManagement;
+#else
+using UnityEditor.Experimental.SceneManagement;
 #endif
 #endif
 

--- a/Assets/Mirror/Editor/NetworkScenePostProcess.cs
+++ b/Assets/Mirror/Editor/NetworkScenePostProcess.cs
@@ -33,9 +33,7 @@ namespace Mirror
                 // if we had a [ConflictComponent] attribute that would be better than this check.
                 // also there is no context about which scene this is in.
                 if (identity.GetComponent<NetworkManager>() != null)
-                {
                     Debug.LogError("NetworkManager has a NetworkIdentity component. This will cause the NetworkManager object to be disabled, so it is not recommended.");
-                }
 
                 // not spawned before?
                 //  OnPostProcessScene is called after additive scene loads too,
@@ -88,22 +86,12 @@ namespace Mirror
             identity.gameObject.SetActive(false);
 
             // safety check for prefabs with more than one NetworkIdentity
-#if UNITY_2018_2_OR_NEWER
             GameObject prefabGO = PrefabUtility.GetCorrespondingObjectFromSource(identity.gameObject);
-#else
-            GameObject prefabGO = PrefabUtility.GetPrefabParent(identity.gameObject);
-#endif
             if (prefabGO)
             {
-#if UNITY_2018_3_OR_NEWER
                 GameObject prefabRootGO = prefabGO.transform.root.gameObject;
-#else
-                GameObject prefabRootGO = PrefabUtility.FindPrefabRoot(prefabGO);
-#endif
                 if (prefabRootGO != null && prefabRootGO.GetComponentsInChildren<NetworkIdentity>().Length > 1)
-                {
                     Debug.LogWarning($"Prefab {prefabRootGO.name} has several NetworkIdentity components attached to itself or its children, this is not supported.");
-                }
             }
         }
     }

--- a/Assets/Mirror/Editor/Weaver/EntryPoint/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/EntryPoint/CompilationFinishedHook.cs
@@ -57,11 +57,7 @@ namespace Mirror.Weaver
                 }
             }
 
-#if UNITY_2019_3_OR_NEWER
             EditorUtility.RequestScriptReload();
-#else
-            UnityEditorInternal.InternalEditorUtility.RequestScriptReload();
-#endif
         }
 
         static Assembly FindCompilationPipelineAssembly(string assemblyName) =>

--- a/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkLoopTests.cs
@@ -1,11 +1,6 @@
 using NUnit.Framework;
-#if UNITY_2019_1_OR_NEWER
 using UnityEngine.LowLevel;
 using UnityEngine.PlayerLoop;
-#else
-using UnityEngine.Experimental.LowLevel;
-using UnityEngine.Experimental.PlayerLoop;
-#endif
 
 namespace Mirror.Tests
 {


### PR DESCRIPTION
We only support Unity 2019.4.40 and later LTS releases.

BREAKING: Removed old 2018 / 2019 compiler defines