### PR TITLE
fix: SnapshotInterpolation: Timescale V2 with dynamic catchup/slowdown

### DIFF
--- a/Assets/Mirror/Core/SnapshotInterpolation/SnapshotInterpolation.cs
+++ b/Assets/Mirror/Core/SnapshotInterpolation/SnapshotInterpolation.cs
@@ -8,6 +8,7 @@
 //   fholm: netcode streams
 //   fakebyte: standard deviation for dynamic adjustment
 //   ninjakicka: math & debugging
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -88,6 +89,7 @@ namespace Mirror
         // note that negative threshold should be <0.
         //   caller should verify (i.e. Unity OnValidate).
         //   improves branch prediction.
+        [Obsolete("use TimescaleV2 instead")]
         public static double Timescale(
             double drift,                    // how far we are off from bufferTime
             double catchupSpeed,             // in % [0,1]

--- a/Assets/Mirror/Core/SnapshotInterpolation/SnapshotInterpolation.cs
+++ b/Assets/Mirror/Core/SnapshotInterpolation/SnapshotInterpolation.cs
@@ -254,7 +254,7 @@ namespace Mirror
                 driftEma.Add(timeDiff);
 
                 // next up, calculate how far we are currently away from bufferTime
-                double drift = driftEma.Value - bufferTime;
+                double absoluteDrift = driftEma.Value - bufferTime;
                 double relativeDrift = driftEma.Value / bufferTime;
 
                 // convert relative thresholds to absolute values based on sendInterval
@@ -266,7 +266,7 @@ namespace Mirror
                 // this way we have 'default' speed most of the time(!).
                 // and only catch up / slow down for a little bit occasionally.
                 // a consistent multiplier would never be exactly 1.0.
-                localTimescale = TimescaleV2(drift, relativeDrift, absoluteNegativeThreshold, absolutePositiveThreshold);
+                localTimescale = TimescaleV2(absoluteDrift, relativeDrift, absoluteNegativeThreshold, absolutePositiveThreshold);
 
                 // debug logging
                 // UnityEngine.Debug.Log($"sendInterval={sendInterval:F3} bufferTime={bufferTime:F3} drift={drift:F3} driftEma={driftEma.Value:F3} timescale={localTimescale:F3} deliveryIntervalEma={deliveryTimeEma.Value:F3}");


### PR DESCRIPTION
**EDIT** since catchup is uses driftEMA, using relative may overshoot if the average is still too high for too long

**BEFORE/AFTER:**
- 1 FPS mode:
  - before 1% catchup: https://gyazo.com/09aae25988f979af50eff4c9b641e878 (catches up fine)
  - before 10% catchup: https://gyazo.com/c22ad365b7804e1015fac08e0a3c5302
  - after: https://gyazo.com/10c0faa40bd46ace34fcd224f5f039b9 (over corrects for too long because it corrects by drift.EMA, which will remain high for a while)
    - current instead of average drift version: https://gyazo.com/ee0677cbec2ca29a3b42b9256868537b
- timeline behind: 
  - before: https://gyazo.com/782de54abb0ea5a94c22dd3fa7e5962d (takes forever to catch up)
  - after: https://gyazo.com/baac170b0848e002bce844c6f2d9395a (catchup is good)
- timeline ahead:
  - before: https://gyazo.com/2748f717408bdc70eb9463eb668403ff (takes forever to slow down)
  - after: https://gyazo.com/582e6d3b38ac993da2a9f01851b260a8 (slowdown is great)

TODO

- [ ] mrg/ninja tests in snap interp demo
- [ ] test in mrg's webgl setup
- [ ] remove debug logs
- [ ] remove the old code
- [ ] consider just one threshold instead of positive+negative
- [ ] unit tests