### PR TITLE
Fix(InterestManagementBase): Disable feature fully, if component unticked.

### DIFF
--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -11,10 +11,10 @@ namespace Mirror
     {
         // Configures InterestManagementBase in NetworkServer/Client
         // Do NOT check for active server or client here.
-        // OnEnabled must always set the static aoi references.
-        // make sure to call base.OnEnabled when overwriting!
+        // OnEnable must always set the static aoi references.
+        // make sure to call base.OnEnable when overwriting!
         // Previously used Awake()
-        protected virtual void OnEnabled()
+        protected virtual void OnEnable()
         {
             if (NetworkServer.aoi == null)
             {

--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -13,7 +13,7 @@ namespace Mirror
         // Do NOT check for active server or client here.
         // Awake must always set the static aoi references.
         // make sure to call base.Awake when overwriting!
-        protected virtual void Awake()
+        protected virtual void OnEnabled()
         {
             if (NetworkServer.aoi == null)
             {

--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -9,10 +9,11 @@ namespace Mirror
     [HelpURL("https://mirror-networking.gitbook.io/docs/guides/interest-management")]
     public abstract class InterestManagementBase : MonoBehaviour
     {
-        // Awake configures InterestManagementBase in NetworkServer/Client
+        // Configures InterestManagementBase in NetworkServer/Client
         // Do NOT check for active server or client here.
-        // Awake must always set the static aoi references.
-        // make sure to call base.Awake when overwriting!
+        // OnEnabled must always set the static aoi references.
+        // make sure to call base.OnEnabled when overwriting!
+        // Previously used Awake()
         protected virtual void OnEnabled()
         {
             if (NetworkServer.aoi == null)


### PR DESCRIPTION
Fix: InterestManagement still partially working when using Awake, OnEnable fixes it.

To test, open CCU Example, build Server with SHIM component disabled on NetworkManager.
Join as client/editor.

You will see client only has objects around itself within SHIM visibility range, despite it being disabled.
Currently if you move player around in this situation, it only ever has that initial network spawn that surrounded it, it never see's new spawns. (it should show all of them from the very beginning)
- We need to stop SHIM from working if its disabled in inspector.

Discussion is in Discord, maybe OnDestroyed needs to become OnDisabled too, but this effects many scripts that use the OnDestroyed Override.
And to note, theres a comment description above the change talking about Awake, that will need to be changed if this PR is considered.

![Screenshot 2023-03-08 at 09 54 57](https://user-images.githubusercontent.com/57072365/223692947-76cb55bc-6cc2-4be5-b178-f314878a792e.jpg)
