### PR TITLE
fix: Snapshot Interpolation time reset if timeline gets too far ahead/behind remote

### DIFF
--- a/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
+++ b/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
@@ -50,6 +50,13 @@ namespace Mirror
         [Range(0, 1)]
         public static double slowdownSpeed = 0.01f; // 1%
 
+        [Header("Snapshot Interpolation: Clamping")]
+        [Tooltip("If the local timeline is so far behind remote time that catchup would take too long, then we do a hard reset so it won't catch up for a minute or more.")]
+        public static float resetNegativeThreshold = catchupNegativeThreshold * 5; // needs to be larger than catchup threshold
+
+        [Tooltip("If the local timeline is so far ahead remote time that slowdown would take too long, then we do a hard reset so it won't slow down for a minute or more.")]
+        public static float resetPositiveThreshold = catchupPositiveThreshold * 5; // needs to be larger than catchup threshold
+
         [Tooltip("Catchup/Slowdown is adjusted over n-second exponential moving average.")]
         public static int driftEmaDuration = 1; // shouldn't need to modify this, but expose it anyway
 
@@ -155,6 +162,8 @@ namespace Mirror
                 ref driftEma,
                 catchupNegativeThreshold,
                 catchupPositiveThreshold,
+                resetNegativeThreshold,
+                resetPositiveThreshold,
                 ref deliveryTimeEma);
 
             // Debug.Log($"inserted TimeSnapshot remote={snap.remoteTime:F2} local={snap.localTime:F2} total={snapshots.Count}");

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -90,6 +90,8 @@ namespace Mirror
                 ref driftEma,
                 NetworkClient.catchupNegativeThreshold,
                 NetworkClient.catchupPositiveThreshold,
+                NetworkClient.resetNegativeThreshold,
+                NetworkClient.resetPositiveThreshold,
                 ref deliveryTimeEma
             );
         }

--- a/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
+++ b/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
@@ -51,6 +51,13 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
         [Range(0, 1)]
         public double slowdownSpeed = 0.01f; // 1%
 
+        [Header("Snapshot Interpolation: Clamping")]
+        [Tooltip("If the local timeline is so far behind remote time that catchup would take too long, then we do a hard reset so it won't catch up for a minute or more.")]
+        public float resetNegativeThreshold = -5; // needs to be larger than catchup threshold
+
+        [Tooltip("If the local timeline is so far ahead remote time that slowdown would take too long, then we do a hard reset so it won't slow down for a minute or more.")]
+        public float resetPositiveThreshold = 5; // needs to be larger than catchup threshold
+
         [Tooltip("Catchup/Slowdown is adjusted over n-second exponential moving average.")]
         public int driftEmaDuration = 1; // shouldn't need to modify this, but expose it anyway
 
@@ -144,6 +151,8 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
                 ref driftEma,
                 catchupNegativeThreshold,
                 catchupPositiveThreshold,
+                resetNegativeThreshold,
+                resetPositiveThreshold,
                 ref deliveryTimeEma);
         }
 

--- a/Assets/Mirror/Examples/Snapshot Interpolation/SnapshotInterpolation.unity
+++ b/Assets/Mirror/Examples/Snapshot Interpolation/SnapshotInterpolation.unity
@@ -176,6 +176,8 @@ MonoBehaviour:
   catchupPositiveThreshold: 1
   catchupSpeed: 0.009999999776482582
   slowdownSpeed: 0.009999999776482582
+  resetNegativeThreshold: -5
+  resetPositiveThreshold: 5
   driftEmaDuration: 1
   dynamicAdjustment: 1
   dynamicAdjustmentTolerance: 1


### PR DESCRIPTION
because catchup / slowdown would then take way too long (10s, 20s, minutes, ...)

WIP