### PR TITLE
fix: Reader / Writer extensions for Unity structs with properties

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -129,14 +129,17 @@ namespace Mirror
         public static Quaternion ReadQuaternion(this NetworkReader reader) => reader.ReadBlittable<Quaternion>();
         public static Quaternion? ReadQuaternionNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Quaternion>();
 
-        public static Rect ReadRect(this NetworkReader reader) => reader.ReadBlittable<Rect>();
-        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Rect>();
+        // Rect is a struct with properties instead of fields
+        public static Rect ReadRect(this NetworkReader reader) => new Rect(reader.ReadVector2(), reader.ReadVector2());
+        public static Rect? ReadRectNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRect(reader) : default(Rect?);
 
-        public static Plane ReadPlane(this NetworkReader reader) => reader.ReadBlittable<Plane>();
-        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Plane>();
+        // Plane is a struct with properties instead of fields
+        public static Plane ReadPlane(this NetworkReader reader) => new Plane(reader.ReadVector3(), reader.ReadFloat());
+        public static Plane? ReadPlaneNullable(this NetworkReader reader) => reader.ReadBool() ? ReadPlane(reader) : default(Plane?);
 
-        public static Ray ReadRay(this NetworkReader reader) => reader.ReadBlittable<Ray>();
-        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBlittableNullable<Ray>();
+        // Ray is a struct with properties instead of fields
+        public static Ray ReadRay(this NetworkReader reader) => new Ray(reader.ReadVector3(), reader.ReadVector3());
+        public static Ray? ReadRayNullable(this NetworkReader reader) => reader.ReadBool() ? ReadRay(reader) : default(Ray?);
 
         public static Matrix4x4 ReadMatrix4x4(this NetworkReader reader) => reader.ReadBlittable<Matrix4x4>();
         public static Matrix4x4? ReadMatrix4x4Nullable(this NetworkReader reader) => reader.ReadBlittableNullable<Matrix4x4>();

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -166,14 +166,46 @@ namespace Mirror
         public static void WriteQuaternion(this NetworkWriter writer, Quaternion value) => writer.WriteBlittable(value);
         public static void WriteQuaternionNullable(this NetworkWriter writer, Quaternion? value) => writer.WriteBlittableNullable(value);
 
-        public static void WriteRect(this NetworkWriter writer, Rect value) => writer.WriteBlittable(value);
-        public static void WriteRectNullable(this NetworkWriter writer, Rect? value) => writer.WriteBlittableNullable(value);
+        // Rect is a struct with properties instead of fields
+        public static void WriteRect(this NetworkWriter writer, Rect value)
+        {
+            writer.WriteVector2(value.position);
+            writer.WriteVector2(value.size);
+        }
+        public static void WriteRectNullable(this NetworkWriter writer, Rect? value)
+        {
+            writer.WriteBool(value.HasValue);
+            if (value.HasValue)
+                writer.WriteRect(value.Value);
+        }
 
-        public static void WritePlane(this NetworkWriter writer, Plane value) => writer.WriteBlittable(value);
-        public static void WritePlaneNullable(this NetworkWriter writer, Plane? value) => writer.WriteBlittableNullable(value);
+        // Plane is a struct with properties instead of fields
+        public static void WritePlane(this NetworkWriter writer, Plane value)
+        {
+            writer.WriteVector3(value.normal);
+            writer.WriteFloat(value.distance);
+        }
 
-        public static void WriteRay(this NetworkWriter writer, Ray value) => writer.WriteBlittable(value);
-        public static void WriteRayNullable(this NetworkWriter writer, Ray? value) => writer.WriteBlittableNullable(value);
+        public static void WritePlaneNullable(this NetworkWriter writer, Plane? value)
+        {
+            writer.WriteBool(value.HasValue);
+            if (value.HasValue)
+                writer.WritePlane(value.Value);
+        }
+
+        // Ray is a struct with properties instead of fields
+        public static void WriteRay(this NetworkWriter writer, Ray value)
+        {
+            writer.WriteVector3(value.origin);
+            writer.WriteVector3(value.direction);
+        }
+
+        public static void WriteRayNullable(this NetworkWriter writer, Ray? value)
+        {
+            writer.WriteBool(value.HasValue);
+            if (value.HasValue)
+                writer.WriteRay(value.Value);
+        }
 
         public static void WriteMatrix4x4(this NetworkWriter writer, Matrix4x4 value) => writer.WriteBlittable(value);
         public static void WriteMatrix4x4Nullable(this NetworkWriter writer, Matrix4x4? value) => writer.WriteBlittableNullable(value);

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -185,7 +185,6 @@ namespace Mirror
             writer.WriteVector3(value.normal);
             writer.WriteFloat(value.distance);
         }
-
         public static void WritePlaneNullable(this NetworkWriter writer, Plane? value)
         {
             writer.WriteBool(value.HasValue);
@@ -199,7 +198,6 @@ namespace Mirror
             writer.WriteVector3(value.origin);
             writer.WriteVector3(value.direction);
         }
-
         public static void WriteRayNullable(this NetworkWriter writer, Ray? value)
         {
             writer.WriteBool(value.HasValue);


### PR DESCRIPTION
Added explicit writer and reader for struct types that don't have public fields, only properties, because WriteBlittable shouldn't work with those.

Oddly, existing tests pass, but users report nulls / empty / default on the receiving side.