### PR TITLE
perf(InterestManagement): Don't Rebuild Observers In OnDestroy

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Match/MatchInterestManagement.cs
@@ -45,12 +45,10 @@ namespace Mirror
         [ServerCallback]
         public override void OnDestroyed(NetworkIdentity identity)
         {
-            if (lastObjectMatch.TryGetValue(identity, out Guid currentMatch))
-            {
-                lastObjectMatch.Remove(identity);
-                if (currentMatch != Guid.Empty && matchObjects.TryGetValue(currentMatch, out HashSet<NetworkIdentity> objects) && objects.Remove(identity))
-                    RebuildMatchObservers(currentMatch);
-            }
+            // Don't RebuildSceneObservers here - that will happen in Update.
+            // Multiple objects could be destroyed in same frame and we don't
+            // want to rebuild for each one...let Update do it once.
+            lastObjectMatch.Remove(identity);
         }
 
         // internal so we can update from tests

--- a/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Scene/SceneInterestManagement.cs
@@ -35,12 +35,10 @@ namespace Mirror
         [ServerCallback]
         public override void OnDestroyed(NetworkIdentity identity)
         {
-            if (lastObjectScene.TryGetValue(identity, out Scene currentScene))
-            {
-                lastObjectScene.Remove(identity);
-                if (sceneObjects.TryGetValue(currentScene, out HashSet<NetworkIdentity> objects) && objects.Remove(identity))
-                    RebuildSceneObservers(currentScene);
-            }
+            // Don't RebuildSceneObservers here - that will happen in Update
+            // multiple objects could be destroyed in same frame and we don't
+            // want to rebuild for each one...let Update do it once.
+            lastObjectScene.Remove(identity);
         }
 
         // internal so we can update from tests

--- a/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Team/TeamInterestManagement.cs
@@ -41,12 +41,10 @@ namespace Mirror
         [ServerCallback]
         public override void OnDestroyed(NetworkIdentity identity)
         {
-            if (lastObjectTeam.TryGetValue(identity, out string currentTeam))
-            {
-                lastObjectTeam.Remove(identity);
-                if (!string.IsNullOrWhiteSpace(currentTeam) && teamObjects.TryGetValue(currentTeam, out HashSet<NetworkIdentity> objects) && objects.Remove(identity))
-                    RebuildTeamObservers(currentTeam);
-            }
+            // Don't RebuildSceneObservers here - that will happen in Update.
+            // Multiple objects could be destroyed in same frame and we don't
+            // want to rebuild for each one...let Update do it once.
+            lastObjectTeam.Remove(identity);
         }
 
         // internal so we can update from tests


### PR DESCRIPTION
Don't Rebuild Observers in OnDestroy...that will happen in Update.
Multiple objects could be destroyed in same frame and we don't want to rebuild for each one...let Update do it once.
