### PR TITLE
fix: Remove all usage of Time.timeAsDouble

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -99,13 +99,8 @@ namespace Mirror
             // NetworkTime.localTime for double precision until Unity has it too
             return new TransformSnapshot(
                 // our local time is what the other end uses as remote time
-#if !UNITY_2020_3_OR_NEWER
                 NetworkTime.localTime, // Unity 2019 doesn't have timeAsDouble yet
-#else
-                Time.timeAsDouble,
-#endif
-                // the other end fills out local time itself
-                0,
+                0,                     // the other end fills out local time itself
                 target.localPosition,
                 target.localRotation,
                 target.localScale
@@ -130,11 +125,7 @@ namespace Mirror
             // insert transform snapshot
             SnapshotInterpolation.InsertIfNotExists(snapshots, new TransformSnapshot(
                 timeStamp, // arrival remote timestamp. NOT remote time.
-#if !UNITY_2020_3_OR_NEWER
                 NetworkTime.localTime, // Unity 2019 doesn't have timeAsDouble yet
-#else
-                Time.timeAsDouble,
-#endif
                 position.Value,
                 rotation.Value,
                 scale.Value

--- a/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
+++ b/Assets/Mirror/Core/NetworkClient_TimeInterpolation.cs
@@ -112,12 +112,8 @@ namespace Mirror
             // before calling OnDeserialize so components can use
             // NetworkTime.time and NetworkTime.timeStamp.
 
-#if !UNITY_2020_3_OR_NEWER
             // Unity 2019 doesn't have Time.timeAsDouble yet
             OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, NetworkTime.localTime));
-#else
-            OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, Time.timeAsDouble));
-#endif
         }
 
         // see comments at the top of this file

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -359,12 +359,8 @@ namespace Mirror
             // maybe we shouldn't allow timeline to deviate more than a certain %.
             // for now, this is only used for client authority movement.
 
-#if !UNITY_2020_3_OR_NEWER
             // Unity 2019 doesn't have Time.timeAsDouble yet
             connection.OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, NetworkTime.localTime));
-#else
-            connection.OnTimeSnapshot(new TimeSnapshot(connection.remoteTimeStamp, Time.timeAsDouble));
-#endif
         }
 
         // connections /////////////////////////////////////////////////////////
@@ -1776,16 +1772,9 @@ namespace Mirror
                 // also important for syncInterval=0 components like
                 // NetworkTransform, so they can sync on same interval as time
                 // snapshots _but_ not every single tick.
-                if (!Application.isPlaying ||
-#if !UNITY_2020_3_OR_NEWER
-                    // Unity 2019 doesn't have Time.timeAsDouble yet
-                    AccurateInterval.Elapsed(NetworkTime.localTime, sendInterval, ref lastSendTime))
-#else
-                    AccurateInterval.Elapsed(Time.timeAsDouble, sendInterval, ref lastSendTime))
-#endif
-                {
+                // Unity 2019 doesn't have Time.timeAsDouble yet
+                if (!Application.isPlaying || AccurateInterval.Elapsed(NetworkTime.localTime, sendInterval, ref lastSendTime))
                     Broadcast();
-                }
             }
 
             // process all outgoing messages after updating the world

--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -6,9 +6,7 @@
 // some users may still be using that.
 using System.Runtime.CompilerServices;
 using UnityEngine;
-#if !UNITY_2020_3_OR_NEWER
 using Stopwatch = System.Diagnostics.Stopwatch;
-#endif
 
 namespace Mirror
 {
@@ -25,21 +23,15 @@ namespace Mirror
 
         static ExponentialMovingAverage _rtt = new ExponentialMovingAverage(PingWindowSize);
 
-        /// <summary>Returns double precision clock time _in this system_, unaffected by the network.</summary>
-#if UNITY_2020_3_OR_NEWER
-        public static double localTime
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Time.timeAsDouble;
-        }
-#else
         // need stopwatch for older Unity versions, but it's quite slow.
         // CAREFUL: unlike Time.time, this is not a FRAME time.
         //          it changes during the frame too.
         static readonly Stopwatch stopwatch = new Stopwatch();
+
         static NetworkTime() => stopwatch.Start();
+
+        /// <summary>Returns double precision clock time _in this system_, unaffected by the network.</summary>
         public static double localTime => stopwatch.Elapsed.TotalSeconds;
-#endif
 
         /// <summary>The time in seconds since the server started.</summary>
         // via global NetworkClient snapshot interpolated timeline (if client).
@@ -77,9 +69,7 @@ namespace Mirror
             PingWindowSize = 6;
             lastPingTime = 0;
             _rtt = new ExponentialMovingAverage(PingWindowSize);
-#if !UNITY_2020_3_OR_NEWER
             stopwatch.Restart();
-#endif
         }
 
         internal static void UpdateClient()

--- a/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
+++ b/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
@@ -69,11 +69,8 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
         public void OnMessage(Snapshot3D snap)
         {
             // set local timestamp (= when it was received on our end)
-#if !UNITY_2020_3_OR_NEWER
+            // Unity 2019 doesn't have Time.timeAsDouble yet
             snap.localTime = NetworkTime.localTime;
-#else
-            snap.localTime = Time.timeAsDouble;
-#endif
 
             // (optional) dynamic adjustment
             if (snapshotSettings.dynamicAdjustment)

--- a/Assets/Mirror/Examples/Snapshot Interpolation/ServerCube.cs
+++ b/Assets/Mirror/Examples/Snapshot Interpolation/ServerCube.cs
@@ -68,11 +68,8 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
         void Send(Vector3 position)
         {
             // create snapshot
-#if !UNITY_2020_3_OR_NEWER
+            // Unity 2019 doesn't have Time.timeAsDouble yet
             Snapshot3D snap = new Snapshot3D(NetworkTime.localTime, 0, position);
-#else
-            Snapshot3D snap = new Snapshot3D(Time.timeAsDouble, 0, position);
-#endif
 
             // simulate packet loss
             bool drop = random.NextDouble() < loss;
@@ -85,11 +82,8 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
 
                 // simulate latency
                 float simulatedLatency = SimulateLatency();
-#if !UNITY_2020_3_OR_NEWER
+                // Unity 2019 doesn't have Time.timeAsDouble yet
                 double deliveryTime = NetworkTime.localTime + simulatedLatency;
-#else
-                double deliveryTime = Time.timeAsDouble + simulatedLatency;
-#endif
                 queue.Insert(index, (deliveryTime, snap));
             }
         }
@@ -100,12 +94,9 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
             for (int i = 0; i < queue.Count; ++i)
             {
                 (double deliveryTime, Snapshot3D snap) = queue[i];
-                
-#if !UNITY_2020_3_OR_NEWER
+
+                // Unity 2019 doesn't have Time.timeAsDouble yet
                 if (NetworkTime.localTime >= deliveryTime)
-#else
-                if (Time.timeAsDouble >= deliveryTime)
-#endif
                 {
                     client.OnMessage(snap);
                     queue.RemoveAt(i);


### PR DESCRIPTION
- Use NetworkTime.localTime everywhere for Unity 2019 LTS compatibility.