### PR TITLE
feature: PortTransport interface for convenience

### DIFF
--- a/Assets/Mirror/Core/PortTransport.cs
+++ b/Assets/Mirror/Core/PortTransport.cs
@@ -1,0 +1,13 @@
+// convenience interface for transports which use a port.
+// useful for cases where someone wants to 'just set the port' independent of
+// which transport it is.
+//
+// note that not all transports have ports, but most do.
+
+namespace  Mirror
+{
+    public interface PortTransport
+    {
+        ushort Port { get; set; }
+    }
+}

--- a/Assets/Mirror/Core/PortTransport.cs.meta
+++ b/Assets/Mirror/Core/PortTransport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7c7c2820d7974cb28c7bfe9aae890a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Transports/KCP/KcpTransport.cs
+++ b/Assets/Mirror/Transports/KCP/KcpTransport.cs
@@ -11,14 +11,16 @@ namespace kcp2k
 {
     [HelpURL("https://mirror-networking.gitbook.io/docs/transports/kcp-transport")]
     [DisallowMultipleComponent]
-    public class KcpTransport : Transport
+    public class KcpTransport : Transport, PortTransport
     {
         // scheme used by this transport
         public const string Scheme = "kcp";
 
         // common
         [Header("Transport Configuration")]
-        public ushort Port = 7777;
+        [FormerlySerializedAs("Port")]
+        public ushort port = 7777;
+        public ushort Port { get => port; set => port=value; }
         [Tooltip("DualMode listens to IPv6 and IPv4 simultaneously. Disable if the platform only supports IPv4.")]
         public bool DualMode = true;
         [Tooltip("NoDelay is recommended to reduce latency. This also scales better without buffers getting full.")]

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -7,13 +7,14 @@ using UnityEngine.Serialization;
 namespace Mirror.SimpleWeb
 {
     [DisallowMultipleComponent]
-    public class SimpleWebTransport : Transport
+    public class SimpleWebTransport : Transport, PortTransport
     {
         public const string NormalScheme = "ws";
         public const string SecureScheme = "wss";
 
         [Tooltip("Port to use for server and client")]
         public ushort port = 7778;
+        public ushort Port { get => port; set => port=value; }
 
         [Tooltip("Protect against allocation attacks by keeping the max message size small. Otherwise an attacker might send multiple fake packets with 2GB headers, causing the server to run out of memory after allocating multiple large packets.")]
         public int maxMessageSize = 16 * 1024;

--- a/Assets/Mirror/Transports/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Transports/Telepathy/TelepathyTransport.cs
@@ -9,13 +9,14 @@ namespace Mirror
 {
     [HelpURL("https://github.com/vis2k/Telepathy/blob/master/README.md")]
     [DisallowMultipleComponent]
-    public class TelepathyTransport : Transport
+    public class TelepathyTransport : Transport, PortTransport
     {
         // scheme used by this transport
         // "tcp4" means tcp with 4 bytes header, network byte order
         public const string Scheme = "tcp4";
 
         public ushort port = 7777;
+        public ushort Port { get => port; set => port=value; }
 
         [Header("Common")]
         [Tooltip("Nagle Algorithm can be disabled by enabling NoDelay")]


### PR DESCRIPTION
merge, not squash.

as requested by lots of users over the years.
some just want to set the transport's port, independent of which transport is active.

alternatively, Kcp : PortTransport : Transport 
if it's a class then Port can be a field and serialized by Unity
