### PR TITLE
fix: make cached SyncVar fallback to original field value when there is no network context

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -648,7 +648,8 @@ namespace Mirror
         protected GameObject GetSyncVarGameObject(uint netId, ref GameObject gameObjectField)
         {
             // server always uses the field
-            if (isServer)
+            // if neither, fallback to original field
+            if (isServer || !isClient)
             {
                 return gameObjectField;
             }
@@ -956,7 +957,8 @@ namespace Mirror
         protected NetworkIdentity GetSyncVarNetworkIdentity(uint netId, ref NetworkIdentity identityField)
         {
             // server always uses the field
-            if (isServer)
+            // if neither, fallback to original field
+            if (isServer || !isClient)
             {
                 return identityField;
             }
@@ -1019,7 +1021,8 @@ namespace Mirror
         protected T GetSyncVarNetworkBehaviour<T>(NetworkBehaviourSyncVar syncNetBehaviour, ref T behaviourField) where T : NetworkBehaviour
         {
             // server always uses the field
-            if (isServer)
+            // if neither, fallback to original field
+            if (isServer || !isClient)
             {
                 return behaviourField;
             }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviourTests.cs
@@ -597,14 +597,12 @@ namespace Mirror.Tests
             NetworkServer.Listen(1);
             ConnectClientBlockingAuthenticatedAndReady(out _);
 
-            CreateNetworked(out GameObject _, out NetworkIdentity identity);
+            // create a networked object with test component
+            CreateNetworked(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourGetSyncVarGameObjectComponent comp);
 
             // are we on client and not on server?
             identity.isClient = true;
             Assert.That(identity.isServer, Is.False);
-
-            // create a networked object with test component
-            CreateNetworked(out GameObject _, out NetworkIdentity _, out NetworkBehaviourGetSyncVarGameObjectComponent comp);
 
             // create a spawned, syncable GameObject
             // (client tries to look up via netid, so needs to be spawned)

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -420,5 +420,56 @@ namespace Mirror.Tests.SyncVarAttributeTests
             Assert.That(clientBehaviour.monster1, Is.EqualTo(serverBehaviour.monster1), "Data should be synchronized");
             Assert.That(clientBehaviour.monster2, Is.EqualTo(serverBehaviour.monster2), "Data should be synchronized");
         }
+
+        // Tests if getter for GameObject SyncVar field returns proper value on server before the containing object is spawned.
+        [Test]
+        public void SyncVarGameObjectGetterOnServerBeforeSpawn()
+        {
+            // The test should only need server objects, but at the same time this belongs in SyncVar tests,
+            // and objects in the tests defined here need client objects to spawn.
+            CreateNetworkedAndSpawn(
+                out GameObject serverGO, out NetworkIdentity serverIdentity, out SyncVarNetworkBehaviour serverNB,
+                out _, out _, out _);
+
+            CreateNetworked(out _, out _, out SyncVarGameObject serverComponent);
+
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            serverComponent.value = serverGO;
+            Assert.That(serverComponent.value, Is.EqualTo(serverGO), "getter should return original field value on server");
+        }
+
+        [Test]
+        public void SyncVarNetworkIdentityGetterOnServerBeforeSpawn()
+        {
+            CreateNetworkedAndSpawn(
+                out GameObject serverGO, out NetworkIdentity serverIdentity, out SyncVarNetworkBehaviour serverNB,
+                out _, out _, out _);
+
+            CreateNetworked(out _, out _, out SyncVarNetworkIdentity serverComponent);
+
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            serverComponent.value = serverIdentity;
+            Assert.That(serverComponent.value, Is.EqualTo(serverIdentity), "getter should return original field value on server");
+        }
+
+        [Test]
+        public void SyncVarNetworkBehaviourGetterOnServerBeforeSpawn()
+        {
+            CreateNetworkedAndSpawn(
+                out GameObject serverGO, out NetworkIdentity serverIdentity, out SyncVarNetworkBehaviour serverNB,
+                out _, out _, out _);
+
+            CreateNetworked(out _, out _, out SyncVarNetworkBehaviour serverComponent);
+
+            Debug.Assert(NetworkClient.active, "NetworkClient needs to be active before spawning.");
+            Debug.Assert(NetworkServer.active, "NetworkServer needs to be active before spawning.");
+
+            serverComponent.value = serverNB;
+            Assert.That(serverComponent.value, Is.EqualTo(serverNB), "getter should return original field value on server");
+        }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -392,6 +392,7 @@ namespace Mirror.Tests.SyncVarAttributeTests
         {
             // set up a "server" object
             CreateNetworked(out _, out NetworkIdentity serverIdentity, out SyncVarAbstractNetworkBehaviour serverBehaviour);
+            serverIdentity.isServer = true;
 
             // spawn syncvar targets
             CreateNetworked(out _, out NetworkIdentity wolfIdentity, out SyncVarAbstractNetworkBehaviour.MockWolf wolf);
@@ -399,6 +400,10 @@ namespace Mirror.Tests.SyncVarAttributeTests
 
             wolfIdentity.netId = 135;
             zombieIdentity.netId = 246;
+
+            // add to spawned as if they were spawned on clients
+            NetworkClient.spawned.Add(wolfIdentity.netId, wolfIdentity);
+            NetworkClient.spawned.Add(zombieIdentity.netId, zombieIdentity);
 
             serverBehaviour.monster1 = wolf;
             serverBehaviour.monster2 = zombie;
@@ -411,14 +416,20 @@ namespace Mirror.Tests.SyncVarAttributeTests
 
             // set up a "client" object
             CreateNetworked(out _, out NetworkIdentity clientIdentity, out SyncVarAbstractNetworkBehaviour clientBehaviour);
+            clientIdentity.isClient = true;
 
             // apply all the data from the server object
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
             clientIdentity.DeserializeClient(reader, true);
 
             // check that the syncvars got updated
+            Debug.Log($"{clientBehaviour.monster1} and {serverBehaviour.monster1}");
             Assert.That(clientBehaviour.monster1, Is.EqualTo(serverBehaviour.monster1), "Data should be synchronized");
             Assert.That(clientBehaviour.monster2, Is.EqualTo(serverBehaviour.monster2), "Data should be synchronized");
+
+            // remove spawned objects
+            NetworkClient.spawned.Remove(wolfIdentity.netId);
+            NetworkClient.spawned.Remove(zombieIdentity.netId);
         }
 
         // Tests if getter for GameObject SyncVar field returns proper value on server before the containing object is spawned.


### PR DESCRIPTION
"Cached SyncVar" as in SyncVars of type `NetworkIdentity`, `NetworkBehaviour` and `GameObject`, which hold netId to prevent the field being forever null.

This fixes #3447 with respective tests for each modified `GetSyncVar~` methods.

PR also modifies some tests that relies on undefined behaviors, which are `GetSyncVarGameObjectOnClient()` and `TestSyncingAbstractNetworkBehaviour()`.

This change also implies that when you access cached SyncVars of non-spawned objects in clients, they will no longer try to pull from `NetworkClient.spawned`. But that doesn't make sense to do in the first place, so I'm pretty sure it's fine.