### PR TITLE
fix: #3457 Make NumSyncVars take parent class syncvars into account

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -481,8 +481,8 @@ namespace Mirror.Weaver
 
             // include parent class syncvars
             // fixes: https://github.com/MirrorNetworking/Mirror/issues/3457
-            syncVarAccessLists.SetNumSyncVars(td.FullName,
-                syncVarAccessLists.GetSyncVarStart(td.BaseType.FullName) + syncVars.Count);
+            int parentSyncVarCount = syncVarAccessLists.GetSyncVarStart(td.BaseType.FullName);
+            syncVarAccessLists.SetNumSyncVars(td.FullName, parentSyncVarCount + syncVars.Count);
 
             return (syncVars, syncVarNetIds);
         }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -478,7 +478,10 @@ namespace Mirror.Weaver
             {
                 td.Fields.Add(fd);
             }
-            syncVarAccessLists.SetNumSyncVars(td.FullName, syncVars.Count);
+
+            // include parent class syncvars
+            syncVarAccessLists.SetNumSyncVars(td.FullName,
+                syncVarAccessLists.GetSyncVarStart(td.BaseType.FullName) + syncVars.Count);
 
             return (syncVars, syncVarNetIds);
         }

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -480,6 +480,7 @@ namespace Mirror.Weaver
             }
 
             // include parent class syncvars
+            // fixes: https://github.com/MirrorNetworking/Mirror/issues/3457
             syncVarAccessLists.SetNumSyncVars(td.FullName,
                 syncVarAccessLists.GetSyncVarStart(td.BaseType.FullName) + syncVars.Count);
 

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeHook_HostModeTest.cs
@@ -2,32 +2,6 @@ using NUnit.Framework;
 
 namespace Mirror.Tests.SyncVarAttributeTests
 {
-    class SyncVarDeepInheritanceHookGuard_0 : NetworkBehaviour
-    {
-        [SyncVar]
-        public int int0;
-    }
-    class SyncVarDeepInheritanceHookGuard_1 : SyncVarDeepInheritanceHookGuard_0
-    {
-        [SyncVar(hook = nameof(OnInt1Changed))]
-        public int int1;
-
-        private void OnInt1Changed(int oldValue, int newValue)
-        {
-            int0--;
-        }
-    }
-    class SyncVarDeepInheritanceHookGuard_2 : SyncVarDeepInheritanceHookGuard_1
-    {
-        [SyncVar(hook = nameof(OnInt2Changed))]
-        public int int2;
-
-        private void OnInt2Changed(int oldValue, int newValue)
-        {
-            int1--;
-        }
-    }
-
     public class SyncVarAttributeHook_HostModeTest : MirrorTest
     {
         [SetUp]
@@ -136,26 +110,6 @@ namespace Mirror.Tests.SyncVarAttributeTests
 
             Assert.That(overrideCallCount, Is.EqualTo(1));
             Assert.That(baseCallCount, Is.EqualTo(0));
-        }
-
-        // SyncVar hook guards are in place to prevent infinite hook loop in host mode.
-        // Because of #3457 this can throw false positive and block setters and hooks of other SyncVars.
-        [Test]
-        public void DeepInheritanceSyncVarHookGuardFalsePositive()
-        {
-            CreateNetworkedAndSpawn(out _, out _, out SyncVarDeepInheritanceHookGuard_2 comp);
-
-            // hooks setters are only called if activeHost
-            Assert.That(NetworkServer.activeHost, Is.True);
-
-            comp.int0 = 10;
-            comp.int1 = 20; // decrements int0 in hook.
-            comp.int2 = 30; // decrements int1 in hook. which then decrements int0.
-
-            // int0 should have been decremented twice.
-            Assert.That(comp.int0, Is.EqualTo(10 - 2), "hook guard should not block hook");
-            // int1 should have been decremented once.
-            Assert.That(comp.int1, Is.EqualTo(20 - 1), "hook guard should not block hook");
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -58,6 +58,27 @@ namespace Mirror.Tests.SyncVarAttributeTests
         public MockMonsterBase monster2;
     }
 
+    class SyncVarDeepInheritanceDirtyBit_0 : NetworkBehaviourSyncVarDirtyBitsExposed
+    {
+        [SyncVar] public int int0;
+        public readonly SyncList<int> list0 = new SyncList<int>();
+    }
+    class SyncVarDeepInheritanceDirtyBit_1 : SyncVarDeepInheritanceDirtyBit_0
+    {
+        [SyncVar] public int int1;
+        public readonly SyncList<int> list1 = new SyncList<int>();
+    }
+    class SyncVarDeepInheritanceDirtyBit_2 : SyncVarDeepInheritanceDirtyBit_1
+    {
+        [SyncVar] public int int2;
+        public readonly SyncList<int> list2 = new SyncList<int>();
+    }
+    class SyncVarDeepInheritanceDirtyBit_3 : SyncVarDeepInheritanceDirtyBit_2
+    {
+        [SyncVar] public int int3;
+        public readonly SyncList<int> list3 = new SyncList<int>();
+    }
+
     public class SyncVarAttributeTest : MirrorTest
     {
         [SetUp]
@@ -472,6 +493,36 @@ namespace Mirror.Tests.SyncVarAttributeTests
 
             serverComponent.value = serverNB;
             Assert.That(serverComponent.value, Is.EqualTo(serverNB), "getter should return original field value on server");
+        }
+
+        [Test]
+        public void DeepInheritanceSyncVarDirtyBitUniqueness()
+        {
+            CreateNetworkedAndSpawn(
+                out _, out _, out SyncVarDeepInheritanceDirtyBit_3 serverObject,
+                out _, out _, out _);
+
+            // test SyncVar dirty bits
+
+            ulong lastSyncVarDirtyBits = serverObject.syncVarDirtyBitsExposed;
+            void AssertUniqueSyncVarDirtyBit()
+            {
+                // check if dirty mask has changed
+                Assert.That(lastSyncVarDirtyBits, Is.Not.EqualTo(serverObject.syncVarDirtyBitsExposed), "every SyncVar dirty bit should be unique");
+                lastSyncVarDirtyBits = serverObject.syncVarDirtyBitsExposed;
+            }
+
+            serverObject.int0 = 1234;
+            AssertUniqueSyncVarDirtyBit();
+
+            serverObject.int1 = 2345;
+            AssertUniqueSyncVarDirtyBit();
+
+            serverObject.int2 = 3456;
+            AssertUniqueSyncVarDirtyBit();
+
+            serverObject.int3 = 4567;
+            AssertUniqueSyncVarDirtyBit();
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -491,6 +491,7 @@ namespace Mirror.Tests.SyncVarAttributeTests
             Assert.That(serverComponent.value, Is.EqualTo(serverNB), "getter should return original field value on server");
         }
 
+        // test for https://github.com/MirrorNetworking/Mirror/issues/3457
         [Test]
         public void DeepInheritanceSyncVarDirtyBitUniqueness()
         {

--- a/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVarAttributeTest.cs
@@ -61,22 +61,18 @@ namespace Mirror.Tests.SyncVarAttributeTests
     class SyncVarDeepInheritanceDirtyBit_0 : NetworkBehaviourSyncVarDirtyBitsExposed
     {
         [SyncVar] public int int0;
-        public readonly SyncList<int> list0 = new SyncList<int>();
     }
     class SyncVarDeepInheritanceDirtyBit_1 : SyncVarDeepInheritanceDirtyBit_0
     {
         [SyncVar] public int int1;
-        public readonly SyncList<int> list1 = new SyncList<int>();
     }
     class SyncVarDeepInheritanceDirtyBit_2 : SyncVarDeepInheritanceDirtyBit_1
     {
         [SyncVar] public int int2;
-        public readonly SyncList<int> list2 = new SyncList<int>();
     }
     class SyncVarDeepInheritanceDirtyBit_3 : SyncVarDeepInheritanceDirtyBit_2
     {
         [SyncVar] public int int3;
-        public readonly SyncList<int> list3 = new SyncList<int>();
     }
 
     public class SyncVarAttributeTest : MirrorTest


### PR DESCRIPTION
This fixes #3457.

In `SyncVarAttributeProcessor.ProcessSyncVars()`, each SyncVar's dirty bit is determined.
To take derived NBs into account, `dirtyBitCounter` starts from base class SyncVar count.
```cs
int dirtyBitCounter = syncVarAccessLists.GetSyncVarStart(td.BaseType.FullName);
```
Which is recorded at the end of `ProcessSyncVars()`.

```cs
List<FieldDefinition> syncVars = new List<FieldDefinition>();

// ...

syncVars.Add(fd);

ProcessSyncVar(td, fd, syncVarNetIds, 1L << dirtyBitCounter, ref WeavingFailed);
dirtyBitCounter += 1;

// ...

syncVarAccessLists.SetNumSyncVars(td.FullName, syncVars.Count);
```

However `syncVars` only has SyncVars from current class, not those from the base class, hence this starts causing problems next round of inheritance.

```cs
public class Entity : NetworkBehaviour
{
    [SyncVar]
    public float health; // dirtyBitCounter starts from 0, dirty bitmask is 1
}

public class Monster : Entity
{
    [SyncVar]
    public float damage; // dirtyBitCounter starts from 1, dirty bitmask is 2
}

public class Monster_Wolf : Monster
{
    [SyncVar]
    public bool isPackLeader; // dirtyBitCounter starts from 1, dirty bitmask is 2
    // which is wrong, it should start from 2, and have bitmask of 4
}

public class Monster_Wolf_Spirit : Monster_Wolf
{
    [SyncVar]
    public float spiritPower; // dirtyBitCounter starts from 1, dirty bitmask is 2
    // which is wrong, it should start from 3, and have bitmask of 8
}
```

In result `damage`, `spiritPower` and `isPackLeader` now shares same dirty bit.

Because Mirror writes and receives every sync variable respective to that dirty bit, state is synced just fine although a bit of unnecessary extra bandwidth is used.
However SyncVar hook guards can act up and cause problem blocking hooks and setters of other variables. (Which is how I found out this bug)

Test `DeepInheritanceSyncVarDirtyBitUniqueness()` tests uniqueness of dirty bits in situations where several levels of inheritance is done in NBs.

Test `DeepInheritanceSyncVarHookGuardFalsePositive()` tests the exact problem I was facing, SyncVar hook guards misfiring and blocking hooks and setters of other variables due to dirty bit collision.

Using the reproduce project in #3457 with fix in place, we can see the bit mask is now properly generated.
![image](https://user-images.githubusercontent.com/41206458/230886904-e0123521-319f-479a-836a-ce4d4b7ab218.png)
 