### PR TITLE
NetworkClient.connection: type changed from NetworkConnection to explicit NetworkConnectionToServer to ensure correct usage. C# has a great type system, we should use to prevent issues.

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -43,7 +43,7 @@ namespace Mirror
             new Dictionary<uint, NetworkIdentity>();
 
         /// <summary>Client's NetworkConnection to server.</summary>
-        public static NetworkConnection connection { get; internal set; }
+        public static NetworkConnectionToServer connection { get; internal set; }
 
         /// <summary>True if client is ready (= joined world).</summary>
         // TODO redundant state. point it to .connection.isReady instead (& test)

--- a/Assets/Mirror/Tests/Common/FakeNetworkConnectionToServer.cs
+++ b/Assets/Mirror/Tests/Common/FakeNetworkConnectionToServer.cs
@@ -1,0 +1,6 @@
+namespace Mirror.Tests
+{
+    public class FakeNetworkConnectionToServer : NetworkConnectionToServer
+    {
+    }
+}

--- a/Assets/Mirror/Tests/Common/FakeNetworkConnectionToServer.cs.meta
+++ b/Assets/Mirror/Tests/Common/FakeNetworkConnectionToServer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f282f856916b42a78e7c5518e8fe52b8
+timeCreated: 1681182286

--- a/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
+++ b/Assets/Mirror/Tests/Editor/ClientSceneTests_OnSpawn.cs
@@ -534,7 +534,7 @@ namespace Mirror.Tests.ClientSceneTests
                 payload = default,
             };
 
-            NetworkClient.connection = new FakeNetworkConnectionToClient();
+            NetworkClient.connection = new FakeNetworkConnectionToServer();
             NetworkClient.ready = true;
             NetworkClient.ApplySpawnPayload(identity, msg);
 


### PR DESCRIPTION
we need to use explicit types for safety.
this way C# type system can catch errors.
notice the unit test being wrong, this wasn't caught before.

TODO

- [ ] 2 failing tests