### PR TITLE
feat(SimpleWebTransport): adding option to set server and client port different

### DIFF
--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -126,6 +126,7 @@ namespace Mirror.SimpleWeb
                 Scheme = GetClientScheme(),
                 Host = hostname,
             };
+            // https://github.com/MirrorNetworking/Mirror/pull/3477
             if (!ClientUseDefaultPort)
                 builder.Port = Port;
 

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -16,6 +16,9 @@ namespace Mirror.SimpleWeb
         public ushort port = 7778;
         public ushort Port { get => port; set => port=value; }
 
+        [Tooltip("Tells the client to use the default port. This is useful when connecting to reverse proxy rather than directly to websocket server")]
+        public bool ClientUseDefaultPort = 7778;
+
         [Tooltip("Protect against allocation attacks by keeping the max message size small. Otherwise an attacker might send multiple fake packets with 2GB headers, causing the server to run out of memory after allocating multiple large packets.")]
         public int maxMessageSize = 16 * 1024;
 
@@ -122,8 +125,9 @@ namespace Mirror.SimpleWeb
             {
                 Scheme = GetClientScheme(),
                 Host = hostname,
-                Port = port
             };
+            if (!ClientUseDefaultPort)
+                builder.Port = Port;
 
             ClientConnect(builder.Uri);
         }


### PR DESCRIPTION
When running websocket server behind reverse proxy client should connect via port 80 or 443. the reverse proxy should then forward requests to the ServerPort  running on localhost.