### PR TITLE
fix: #3478 revert NetworkTransform hacks

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -57,31 +57,6 @@ namespace Mirror
         [Tooltip("Set to false to remove scale smoothing. Example use-case: Instant flipping of sprites that use -X and +X for direction.")]
         public bool interpolateScale = true;
 
-        [Header("Send Interval Multiplier")]
-        [Tooltip("Check/Sync every multiple of Network Manager send interval (= 1 / NM Send Rate), instead of every send interval.")]
-        [Range(1, 120)]
-        public uint sendIntervalMultiplier = 1; // not implemented yet
-
-        [Header("Timeline Offset")]
-        [Tooltip("Add a small timeline offset to account for decoupled arrival of NetworkTime and NetworkTransform snapshots.\nfixes: https://github.com/MirrorNetworking/Mirror/issues/3427")]
-        public bool timelineOffset = false;
-
-        // Ninja's Notes on offset & mulitplier:
-        // 
-        // In a no multiplier scenario:
-        // 1. Snapshots are sent every frame (frame being 1 NM send interval).
-        // 2. Time Interpolation is set to be 'behind' by 2 frames times.
-        // In theory where everything works, we probably have around 2 snapshots before we need to interpolate snapshots. From NT perspective, we should always have around 2 snapshots ready, so no stutter.
-        // 
-        // In a multiplier scenario:
-        // 1. Snapshots are sent every 10 frames.
-        // 2. Time Interpolation remains 'behind by 2 frames'.
-        // When everything works, we are receiving NT snapshots every 10 frames, but start interpolating after 2. 
-        // Even if I assume we had 2 snapshots to begin with to start interpolating (which we don't), by the time we reach 13th frame, we are out of snapshots, and have to wait 7 frames for next snapshot to come. This is the reason why we absolutely need the timestamp adjustment. We are starting way too early to interpolate. 
-        //
-        protected double timeStampAdjustment => NetworkServer.sendInterval * (sendIntervalMultiplier - 1);
-        protected double offset => timelineOffset ? NetworkServer.sendInterval * sendIntervalMultiplier : 0;
-
         // debugging ///////////////////////////////////////////////////////////
         [Header("Debug")]
         public bool showGizmos;
@@ -124,8 +99,13 @@ namespace Mirror
             // NetworkTime.localTime for double precision until Unity has it too
             return new TransformSnapshot(
                 // our local time is what the other end uses as remote time
+#if !UNITY_2020_3_OR_NEWER
                 NetworkTime.localTime, // Unity 2019 doesn't have timeAsDouble yet
-                0,                     // the other end fills out local time itself
+#else
+                Time.timeAsDouble,
+#endif
+                // the other end fills out local time itself
+                0,
                 target.localPosition,
                 target.localRotation,
                 target.localScale
@@ -150,7 +130,11 @@ namespace Mirror
             // insert transform snapshot
             SnapshotInterpolation.InsertIfNotExists(snapshots, new TransformSnapshot(
                 timeStamp, // arrival remote timestamp. NOT remote time.
+#if !UNITY_2020_3_OR_NEWER
                 NetworkTime.localTime, // Unity 2019 doesn't have timeAsDouble yet
+#else
+                Time.timeAsDouble,
+#endif
                 position.Value,
                 rotation.Value,
                 scale.Value

--- a/Assets/Mirror/Components/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransformBase.cs
@@ -29,7 +29,6 @@ namespace Mirror
         [Tooltip("The Transform component to sync. May be on on this GameObject, or on a child.")]
         public Transform target;
 
-        // TODO SyncDirection { ClientToServer, ServerToClient } is easier?
         // Deprecated 2022-10-25
         [Obsolete("NetworkTransform clientAuthority was replaced with syncDirection. To enable client authority, set SyncDirection to ClientToServer in the Inspector.")]
         [Header("[Obsolete]")] // Unity doesn't show obsolete warning for fields. do it manually.

--- a/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
@@ -11,10 +11,6 @@ namespace Mirror
         [Header("Sync Only If Changed")]
         [Tooltip("When true, changes are not sent unless greater than sensitivity values below.")]
         public bool onlySyncOnChange = true;
-
-        uint sendIntervalCounter = 0;
-        double lastSendIntervalTime = double.MinValue;
-
         [Tooltip("If we only sync on change, then we need to correct old snapshots if more time than sendInterval * multiplier has elapsed.\n\nOtherwise the first move will always start interpolating from the last move sequence's time, which will make it stutter when starting every time.")]
         public float onlySyncOnChangeCorrectionMultiplier = 2;
 
@@ -37,6 +33,10 @@ namespace Mirror
         [Range(0.00_01f, 1f)]                   // disallow 0 division. 1mm to 1m precision is enough range.
         public float scalePrecision = 0.01f; // 1 cm
 
+        [Header("Snapshot Interpolation")]
+        [Tooltip("Add a small timeline offset to account for decoupled arrival of NetworkTime and NetworkTransform snapshots.\nfixes: https://github.com/MirrorNetworking/Mirror/issues/3427")]
+        public bool timelineOffset = false;
+
         // delta compression needs to remember 'last' to compress against
         protected Vector3Long lastSerializedPosition = Vector3Long.zero;
         protected Vector3Long lastDeserializedPosition = Vector3Long.zero;
@@ -47,9 +47,8 @@ namespace Mirror
         // Used to store last sent snapshots
         protected TransformSnapshot last;
 
-        protected int lastClientCount = 1;
-
         // update //////////////////////////////////////////////////////////////
+        // Update applies interpolation.
         void Update()
         {
             // if server then always sync to others.
@@ -59,19 +58,18 @@ namespace Mirror
             else if (isClient) UpdateClient();
         }
 
+        // LateUpdate sets dirty.
+        // movement scripts may change positions in Update.
+        // use LateUpdate to ensure changes are detected in the same frame.
+        // otherwise this may run before user update, delaying detection until next frame.
+        // this would cause visible jitter.
         void LateUpdate()
         {
             // set dirty to trigger OnSerialize. either always, or only if changed.
-            // It has to be checked in LateUpdate() for onlySyncOnChange to avoid
-            // the possibility of Update() running first before the object's movement
-            // script's Update(), which then causes NT to send every alternate frame
-            // instead.
-            if (isServer || (IsClientWithAuthority && NetworkClient.ready))
+            if (isServer || (IsClientWithAuthority && NetworkClient.ready)) // is NetworkClient.ready even needed?
             {
-                if (sendIntervalCounter == sendIntervalMultiplier && (!onlySyncOnChange || Changed(Construct())))
+                if (!onlySyncOnChange || Changed(Construct()))
                     SetDirty();
-
-                CheckLastSendTime();
             }
         }
 
@@ -128,19 +126,6 @@ namespace Mirror
                     TransformSnapshot computed = TransformSnapshot.Interpolate(from, to, t);
                     Apply(computed, to);
                 }
-
-                lastClientCount = clientSnapshots.Count;
-            }
-        }
-
-        protected virtual void CheckLastSendTime()
-        {
-            // timeAsDouble not available in older Unity versions.
-            if (AccurateInterval.Elapsed(NetworkTime.localTime, NetworkServer.sendInterval, ref lastSendIntervalTime))
-            {
-                if (sendIntervalCounter == sendIntervalMultiplier)
-                    sendIntervalCounter = 0;
-                sendIntervalCounter++;
             }
         }
 
@@ -188,16 +173,6 @@ namespace Mirror
             // initial
             if (initialState)
             {
-                // If there is a last serialized snapshot, we use it.
-                // This prevents the new client getting a snapshot that is different
-                // from what the older clients last got. If this happens, and on the next
-                // regular serialisation the delta compression will get wrong values.
-                // Notes:
-                // 1. Interestingly only the older clients have it wrong, because at the end
-                //    of this function, last = snapshot which is the initial state's snapshot
-                // 2. Regular NTR gets by this bug because it sends every frame anyway so initialstate
-                //    snapshot constructed would have been the same as the last anyway.
-                if (last.remoteTime > 0) snapshot = last;
                 if (syncPosition) writer.WriteVector3(snapshot.position);
                 if (syncRotation)
                 {
@@ -234,6 +209,9 @@ namespace Mirror
                     Compression.ScaleToLong(snapshot.scale, scalePrecision, out Vector3Long quantized);
                     DeltaCompression.Compress(writer, lastSerializedScale, quantized);
                 }
+
+                // int written = writer.Position - before;
+                // Debug.Log($"{name} compressed to {written} bytes");
             }
 
             // save serialized as 'last' for next delta compression
@@ -311,16 +289,17 @@ namespace Mirror
 
             // 'only sync on change' needs a correction on every new move sequence.
             if (onlySyncOnChange &&
-                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval, onlySyncOnChangeCorrectionMultiplier))
             {
                 RewriteHistory(
                     serverSnapshots,
                     connectionToClient.remoteTimeStamp,
-                    NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
-                    NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
+                    NetworkTime.localTime,      // arrival remote timestamp. NOT remote timeline.
+                    NetworkServer.sendInterval, // Unity 2019 doesn't have timeAsDouble yet
                     target.localPosition,
                     target.localRotation,
                     target.localScale);
+                // Debug.Log($"{name}: corrected history on server to fix initial stutter after not sending for a while.");
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -328,7 +307,8 @@ namespace Mirror
             // needs to be sendInterval. half sendInterval doesn't solve it.
             // https://github.com/MirrorNetworking/Mirror/issues/3427
             // remove this after LocalWorldState.
-            AddSnapshot(serverSnapshots, connectionToClient.remoteTimeStamp + timeStampAdjustment + offset, position, rotation, scale);
+            double offset = timelineOffset ? NetworkServer.sendInterval : 0;
+            AddSnapshot(serverSnapshots, connectionToClient.remoteTimeStamp + offset, position, rotation, scale);
         }
 
         // server broadcasts sync message to all clients
@@ -339,16 +319,17 @@ namespace Mirror
 
             // 'only sync on change' needs a correction on every new move sequence.
             if (onlySyncOnChange &&
-                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval, onlySyncOnChangeCorrectionMultiplier))
             {
                 RewriteHistory(
                     clientSnapshots,
-                    NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
-                    NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
-                    NetworkClient.sendInterval * sendIntervalMultiplier,
+                    NetworkClient.connection.remoteTimeStamp, // arrival remote timestamp. NOT remote timeline.
+                    NetworkTime.localTime,                    // Unity 2019 doesn't have timeAsDouble yet
+                    NetworkClient.sendInterval,
                     target.localPosition,
                     target.localRotation,
                     target.localScale);
+                // Debug.Log($"{name}: corrected history on client to fix initial stutter after not sending for a while.");
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -356,7 +337,8 @@ namespace Mirror
             // needs to be sendInterval. half sendInterval doesn't solve it.
             // https://github.com/MirrorNetworking/Mirror/issues/3427
             // remove this after LocalWorldState.
-            AddSnapshot(clientSnapshots, NetworkClient.connection.remoteTimeStamp + timeStampAdjustment + offset, position, rotation, scale);
+            double offset = timelineOffset ? NetworkServer.sendInterval : 0;
+            AddSnapshot(clientSnapshots, NetworkClient.connection.remoteTimeStamp + offset, position, rotation, scale);
         }
 
         // only sync on change /////////////////////////////////////////////////

--- a/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransformReliable/NetworkTransformReliable.cs
@@ -1,6 +1,4 @@
 // NetworkTransform V3 (reliable) by mischa (2022-10)
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Mirror
@@ -8,15 +6,7 @@ namespace Mirror
     [AddComponentMenu("Network/Network Transform (Reliable)")]
     public class NetworkTransformReliable : NetworkTransformBase
     {
-        [Header("Sync Only If Changed")]
-        [Tooltip("When true, changes are not sent unless greater than sensitivity values below.")]
-        public bool onlySyncOnChange = true;
-        [Tooltip("If we only sync on change, then we need to correct old snapshots if more time than sendInterval * multiplier has elapsed.\n\nOtherwise the first move will always start interpolating from the last move sequence's time, which will make it stutter when starting every time.")]
-        public float onlySyncOnChangeCorrectionMultiplier = 2;
-
         [Header("Rotation")]
-        [Tooltip("Sensitivity of changes needed before an updated state is sent over the network")]
-        public float rotationSensitivity = 0.01f;
         [Tooltip("Apply smallest-three quaternion compression. This is lossy, you can disable it if the small rotation inaccuracies are noticeable in your project.")]
         public bool compressRotation = false;
 
@@ -44,9 +34,6 @@ namespace Mirror
         protected Vector3Long lastSerializedScale = Vector3Long.zero;
         protected Vector3Long lastDeserializedScale = Vector3Long.zero;
 
-        // Used to store last sent snapshots
-        protected TransformSnapshot last;
-
         // update //////////////////////////////////////////////////////////////
         // Update applies interpolation.
         void Update()
@@ -68,8 +55,7 @@ namespace Mirror
             // set dirty to trigger OnSerialize. either always, or only if changed.
             if (isServer || (IsClientWithAuthority && NetworkClient.ready)) // is NetworkClient.ready even needed?
             {
-                if (!onlySyncOnChange || Changed(Construct()))
-                    SetDirty();
+                SetDirty();
             }
         }
 
@@ -127,29 +113,6 @@ namespace Mirror
                     Apply(computed, to);
                 }
             }
-        }
-
-        // check if position / rotation / scale changed since last sync
-        protected virtual bool Changed(TransformSnapshot current) =>
-            // position is quantized and delta compressed.
-            // only consider it changed if the quantized representation is changed.
-            // careful: don't use 'serialized / deserialized last'. as it depends on sync mode etc.
-            QuantizedChanged(last.position, current.position, positionPrecision) ||
-            // rotation isn't quantized / delta compressed.
-            // check with sensitivity.
-            Quaternion.Angle(last.rotation, current.rotation) > rotationSensitivity ||
-            // scale is quantized and delta compressed.
-            // only consider it changed if the quantized representation is changed.
-            // careful: don't use 'serialized / deserialized last'. as it depends on sync mode etc.
-            QuantizedChanged(last.scale, current.scale, scalePrecision);
-
-        // helper function to compare quantized representations of a Vector3
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected bool QuantizedChanged(Vector3 u, Vector3 v, float precision)
-        {
-            Compression.ScaleToLong(u, precision, out Vector3Long uQuantized);
-            Compression.ScaleToLong(v, precision, out Vector3Long vQuantized);
-            return uQuantized != vQuantized;
         }
 
         // NT may be used on client/server/host to Owner/Observers with
@@ -217,9 +180,6 @@ namespace Mirror
             // save serialized as 'last' for next delta compression
             if (syncPosition) Compression.ScaleToLong(snapshot.position, positionPrecision, out lastSerializedPosition);
             if (syncScale) Compression.ScaleToLong(snapshot.scale, scalePrecision, out lastSerializedScale);
-
-            // set 'last'
-            last = snapshot;
         }
 
         public override void OnDeserialize(NetworkReader reader, bool initialState)
@@ -287,21 +247,6 @@ namespace Mirror
             // protect against ever growing buffer size attacks
             if (serverSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
-            // 'only sync on change' needs a correction on every new move sequence.
-            if (onlySyncOnChange &&
-                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval, onlySyncOnChangeCorrectionMultiplier))
-            {
-                RewriteHistory(
-                    serverSnapshots,
-                    connectionToClient.remoteTimeStamp,
-                    NetworkTime.localTime,      // arrival remote timestamp. NOT remote timeline.
-                    NetworkServer.sendInterval, // Unity 2019 doesn't have timeAsDouble yet
-                    target.localPosition,
-                    target.localRotation,
-                    target.localScale);
-                // Debug.Log($"{name}: corrected history on server to fix initial stutter after not sending for a while.");
-            }
-
             // add a small timeline offset to account for decoupled arrival of
             // NetworkTime and NetworkTransform snapshots.
             // needs to be sendInterval. half sendInterval doesn't solve it.
@@ -317,21 +262,6 @@ namespace Mirror
             // don't apply for local player with authority
             if (IsClientWithAuthority) return;
 
-            // 'only sync on change' needs a correction on every new move sequence.
-            if (onlySyncOnChange &&
-                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval, onlySyncOnChangeCorrectionMultiplier))
-            {
-                RewriteHistory(
-                    clientSnapshots,
-                    NetworkClient.connection.remoteTimeStamp, // arrival remote timestamp. NOT remote timeline.
-                    NetworkTime.localTime,                    // Unity 2019 doesn't have timeAsDouble yet
-                    NetworkClient.sendInterval,
-                    target.localPosition,
-                    target.localRotation,
-                    target.localScale);
-                // Debug.Log($"{name}: corrected history on client to fix initial stutter after not sending for a while.");
-            }
-
             // add a small timeline offset to account for decoupled arrival of
             // NetworkTime and NetworkTransform snapshots.
             // needs to be sendInterval. half sendInterval doesn't solve it.
@@ -342,47 +272,6 @@ namespace Mirror
         }
 
         // only sync on change /////////////////////////////////////////////////
-        // snap interp. needs a continous flow of packets.
-        // 'only sync on change' interrupts it while not changed.
-        // once it restarts, snap interp. will interp from the last old position.
-        // this will cause very noticeable stutter for the first move each time.
-        // the fix is quite simple.
-
-        // 1. detect if the remaining snapshot is too old from a past move.
-        static bool NeedsCorrection(
-            SortedList<double, TransformSnapshot> snapshots,
-            double remoteTimestamp,
-            double bufferTime,
-            double toleranceMultiplier) =>
-                snapshots.Count == 1 &&
-                remoteTimestamp - snapshots.Keys[0] >= bufferTime * toleranceMultiplier;
-
-        // 2. insert a fake snapshot at current position,
-        //    exactly one 'sendInterval' behind the newly received one.
-        static void RewriteHistory(
-            SortedList<double, TransformSnapshot> snapshots,
-            // timestamp of packet arrival, not interpolated remote time!
-            double remoteTimeStamp,
-            double localTime,
-            double sendInterval,
-            Vector3 position,
-            Quaternion rotation,
-            Vector3 scale)
-        {
-            // clear the previous snapshot
-            snapshots.Clear();
-
-            // insert a fake one at where we used to be,
-            // 'sendInterval' behind the new one.
-            SnapshotInterpolation.InsertIfNotExists(snapshots, new TransformSnapshot(
-                remoteTimeStamp - sendInterval, // arrival remote timestamp. NOT remote time.
-                localTime - sendInterval,       // Unity 2019 doesn't have timeAsDouble yet
-                position,
-                rotation,
-                scale
-            ));
-        }
-
         public override void Reset()
         {
             base.Reset();
@@ -393,9 +282,6 @@ namespace Mirror
 
             lastSerializedScale = Vector3Long.zero;
             lastDeserializedScale = Vector3Long.zero;
-
-            // reset 'last' for delta too
-            last = new TransformSnapshot(0, 0, Vector3.zero, Quaternion.identity, Vector3.zero);
         }
     }
 }


### PR DESCRIPTION
Focus on stability & correctness.
Look into begin/update/end move NT for bandwidth savings.
Building one complex hack on another is not the solution here.