### PR TITLE
fix: Disallow Child-NetworkIdentities in Scene objects

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -534,6 +534,9 @@ namespace Mirror
                 return;
             }
 
+            // disallow child NetworkIdentities.
+            // TODO likely not necessary anymore due to the new check in
+            // NetworkIdentity.OnValidate.
             NetworkIdentity[] identities = prefab.GetComponentsInChildren<NetworkIdentity>();
             if (identities.Length > 1)
             {

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -369,7 +369,9 @@ namespace Mirror
 #endif
             if (identities.Length > 1)
             {
-                Debug.LogError($"'{name}' has {identities.Length} NetworkIdentity components. There should only be one NetworkIdentity, and it must be on the root object.");
+                // always log the next child component so it's easy to fix.
+                // if there are multiple, then after removing it'll log the next.
+                Debug.LogError($"'{name}' has another NetworkIdentity component on '{identities[1].name}'. There should only be one NetworkIdentity, and it must be on the root object. Please remove the other one.");
             }
         }
 

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -350,11 +350,29 @@ namespace Mirror
             hasSpawned = false;
 
 #if UNITY_EDITOR
+            DisallowChildNetworkIdentities();
             SetupIDs();
 #endif
         }
 
 #if UNITY_EDITOR
+        // child NetworkIdentities are not supported.
+        // Disallow them and show an error for the user to fix.
+        // This needs to work for Prefabs & Scene objects, so the previous check
+        // in NetworkClient.RegisterPrefab is not enough.
+        void DisallowChildNetworkIdentities()
+        {
+#if UNITY_2020_3_OR_NEWER
+            NetworkIdentity[] identities = GetComponentsInChildren<NetworkIdentity>(true);
+#else
+            NetworkIdentity[] identities = GetComponentsInChildren<NetworkIdentity>();
+#endif
+            if (identities.Length > 1)
+            {
+                Debug.LogError($"'{name}' has {identities.Length} NetworkIdentity components. There should only be one NetworkIdentity, and it must be on the root object.");
+            }
+        }
+
         void AssignAssetID(string path)
         {
             // only set if not empty. fixes https://github.com/vis2k/Mirror/issues/2765


### PR DESCRIPTION
<img width="1163" alt="2023-05-27 - 08-29-57@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/e17ee2c0-1858-469d-a1e0-df763650bb0d">
