### PR TITLE
Changed default NT BRM to 3

### DIFF
--- a/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkTransform.cs
+++ b/Assets/Mirror/Components/NetworkTransformUnreliable/NetworkTransform.cs
@@ -17,9 +17,9 @@ namespace Mirror
         uint sendIntervalCounter = 0;
         double lastSendIntervalTime = double.MinValue;
 
-        // 3 was original, but testing under really bad network conditions, 2%-5% packet loss and 250-1200ms ping, 5 proved to eliminate any twitching.
-        [Tooltip("How much time, as a multiple of send interval, has passed before clearing buffers.\nA larger buffer means more delay, but results in smoother movement.\n3 is recommended for faster responses, with minor smoothing. ")]
-        public float bufferResetMultiplier = 5;
+        // Testing under really bad network conditions, 2%-5% packet loss and 250-1200ms ping, 5 proved to eliminate any twitching, however this should not be the default as it is a rare case Developers may want to cover.
+        [Tooltip("How much time, as a multiple of send interval, has passed before clearing buffers.\nA larger buffer means more delay, but results in smoother movement.\nExample: 1 for faster responses minimal smoothing, 5 covers bad pings but has noticable delay, 3 is recommended for balanced results,.")]
+        public float bufferResetMultiplier = 3;
 
         [Header("Sensitivity"), Tooltip("Sensitivity of changes needed before an updated state is sent over the network")]
         public float positionSensitivity = 0.01f;


### PR DESCRIPTION
5 (the previous default) covers really bad pings in return for noticeable delay.
However, not every game should have this as their default.
With something as low as 1 being almost instant movement for minimal smoothing (could be best for VR and other uses), from testing 3 is a nice balanced result between the two variations.

Tested with different network manager send rates, tanks example (body and turret NT's), bufferResetMultiplier 1,3 and 5, with a few latency simulator variations too.