### PR TITLE
fix: Temporarily disable 2022 CI

### DIFF
--- a/.github/workflows/RunUnityTests.yml
+++ b/.github/workflows/RunUnityTests.yml
@@ -14,7 +14,7 @@ jobs:
           - 2019.4.40f1
           - 2020.3.48f1
           - 2021.3.26f1
-          - 2022.2.21f1
+#          - 2022.2.21f1
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Seems like testing is broken in 2022.2, so temporarily disable until we fix them properly