### PR TITLE
feat: adding option to get Ip behind reverse proxy

### DIFF
--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/AssemblyInfo.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.6.0")]
 
 [assembly: InternalsVisibleTo("SimpleWebTransport.Tests.Runtime")]
 [assembly: InternalsVisibleTo("SimpleWebTransport.Tests.Editor")]

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -121,8 +121,12 @@ namespace Mirror.SimpleWeb
                 // Remove the port number from the address
                 return actualClientIP.Split(':').First();
             }
-
-            return client.Client.RemoteEndPoint.ToString();
+            else
+            {
+                System.Net.IPEndPoint ipEndPoint = (System.Net.IPEndPoint)client.Client.RemoteEndPoint;
+                System.Net.IPAddress ipAddress = ipEndPoint.Address.MapToIPv4();
+                return ipAddress.ToString();
+            }
         }
     }
 }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -115,10 +115,9 @@ namespace Mirror.SimpleWeb
         /// <exception cref="NotImplementedException"></exception>
         internal string CalculateAddress()
         {
-            var headers = request.Headers;
-            if (headers.TryGetValue("X-Forwarded-For", out var forwardFor))
+            if (request.Headers.TryGetValue("X-Forwarded-For", out string forwardFor))
             {
-                var actualClientIP = forwardFor.ToString().Split(',').First();
+                string actualClientIP = forwardFor.ToString().Split(',').First();
                 // Remove the port number from the address
                 return actualClientIP.Split(':').First();
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -121,8 +122,8 @@ namespace Mirror.SimpleWeb
             }
             else
             {
-                System.Net.IPEndPoint ipEndPoint = (System.Net.IPEndPoint)client.Client.RemoteEndPoint;
-                System.Net.IPAddress ipAddress = ipEndPoint.Address;
+                IPEndPoint ipEndPoint = (IPEndPoint)client.Client.RemoteEndPoint;
+                IPAddress ipAddress = ipEndPoint.Address;
                 if (ipAddress.IsIPv4MappedToIPv6)
                     ipAddress.MapToIPv4();
 

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -21,6 +21,12 @@ namespace Mirror.SimpleWeb
         /// <para>Only valid on server</para>
         /// </summary>
         public Request request;
+        /// <summary>
+        /// RemoteEndpoint address or address from request header
+        /// <para>Only valid on server</para>
+        /// </summary>
+        public string remoteAddress;
+
 
         public Stream stream;
         public Thread receiveThread;
@@ -99,6 +105,26 @@ namespace Mirror.SimpleWeb
                 {
                     return $"[Conn:{connId}, endPoint:n/a]";
                 }
+        }
+
+        /// <summary>
+        /// Gets the address based on the <see cref="request"/> and RemoteEndPoint
+        /// <para>Called after ServerHandShake is accepted</para>
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        internal string CalculateAddress()
+        {
+            var headers = request.Headers;
+            if (headers.TryGetValue("X-Forwarded-For", out var forwardFor))
+            {
+                var ips = forwardFor.ToString().Split(',');
+                var actualClientIP = ips[0];
+                // Remove the port number from the address
+                string addressWithoutPort = remoteAddress.Split(':')[0];
+                return addressWithoutPort;
+            }
+
+            return client.Client.RemoteEndPoint.ToString();
         }
     }
 }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -15,6 +15,13 @@ namespace Mirror.SimpleWeb
         public TcpClient client;
 
         public int connId = IdNotSet;
+
+        /// <summary>
+        /// Connect request, sent from client to start handshake
+        /// <para>Only valid on server</para>
+        /// </summary>
+        public Request request;
+
         public Stream stream;
         public Thread receiveThread;
         public Thread sendThread;

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -125,7 +125,7 @@ namespace Mirror.SimpleWeb
                 IPEndPoint ipEndPoint = (IPEndPoint)client.Client.RemoteEndPoint;
                 IPAddress ipAddress = ipEndPoint.Address;
                 if (ipAddress.IsIPv4MappedToIPv6)
-                    ipAddress.MapToIPv4();
+                    ipAddress = ipAddress.MapToIPv4();
 
                 return ipAddress.ToString();
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -10,8 +10,7 @@ namespace Mirror.SimpleWeb
     internal sealed class Connection : IDisposable
     {
         public const int IdNotSet = -1;
-
-        readonly object disposedLock = new object();
+        private readonly object disposedLock = new object();
 
         public TcpClient client;
 
@@ -37,8 +36,7 @@ namespace Mirror.SimpleWeb
         public ConcurrentQueue<ArrayBuffer> sendQueue = new ConcurrentQueue<ArrayBuffer>();
 
         public Action<Connection> onDispose;
-
-        volatile bool hasDisposed;
+        private volatile bool hasDisposed;
 
         public Connection(TcpClient client, Action<Connection> onDispose)
         {
@@ -124,7 +122,10 @@ namespace Mirror.SimpleWeb
             else
             {
                 System.Net.IPEndPoint ipEndPoint = (System.Net.IPEndPoint)client.Client.RemoteEndPoint;
-                System.Net.IPAddress ipAddress = ipEndPoint.Address.MapToIPv4();
+                System.Net.IPAddress ipAddress = ipEndPoint.Address;
+                if (ipAddress.IsIPv4MappedToIPv6)
+                    ipAddress.MapToIPv4();
+
                 return ipAddress.ToString();
             }
         }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Connection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -117,11 +118,9 @@ namespace Mirror.SimpleWeb
             var headers = request.Headers;
             if (headers.TryGetValue("X-Forwarded-For", out var forwardFor))
             {
-                var ips = forwardFor.ToString().Split(',');
-                var actualClientIP = ips[0];
+                var actualClientIP = forwardFor.ToString().Split(',').First();
                 // Remove the port number from the address
-                string addressWithoutPort = remoteAddress.Split(':')[0];
-                return addressWithoutPort;
+                return actualClientIP.Split(':').First();
             }
 
             return client.Client.RemoteEndPoint.ToString();

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
@@ -18,8 +18,7 @@ namespace Mirror.SimpleWeb
             string[] all = message.Split(lineSplitChars, StringSplitOptions.RemoveEmptyEntries);
             RequestLine = all.First();
             Headers = all.Skip(1)
-                         .Select(header => header.Split(':'))
-                         .Where(split => split.Length == 2)
+                         .Select(header => header.Split(':', 2, StringSplitOptions.RemoveEmptyEntries))
                          .ToDictionary(split => split[0].Trim(), split => split[1].Trim());
         }
     }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
@@ -16,8 +16,7 @@ namespace Mirror.SimpleWeb
         public Request(string message)
         {
             string[] all = message.Split(lineSplitChars, StringSplitOptions.RemoveEmptyEntries);
-            // we need to add GET back in because ServerHandshake doesn't include it
-            RequestLine = $"GET{all[0]}";
+            RequestLine = all.First();
             Headers = all.Skip(1)
                          .Select(header => header.Split(':'))
                          .Where(split => split.Length == 2)

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mirror.SimpleWeb
+{
+    /// <summary>
+    /// Represents a client's request to the Websockets server, which is the first message from the client.
+    /// </summary>
+    public class Request
+    {
+        private static readonly char[] lineSplitChars = new char[] { '\r', '\n' };
+        public string RequestLine;
+        public Dictionary<string, string> Headers = new Dictionary<string, string>();
+
+        public Request(string message)
+        {
+            string[] all = message.Split(lineSplitChars, StringSplitOptions.RemoveEmptyEntries);
+            // we need to add GET back in because ServerHandshake doesn't include it
+            RequestLine = "GET" + all[0];
+            for (int i = 1; i < all.Length; i++)
+            {
+                string[] split = all[i].Split(':');
+                if (split.Length == 2)
+                {
+                    Headers.Add(split[0].Trim(), split[1].Trim());
+                }
+            }
+        }
+    }
+}

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Mirror.SimpleWeb
 {
@@ -17,14 +18,10 @@ namespace Mirror.SimpleWeb
             string[] all = message.Split(lineSplitChars, StringSplitOptions.RemoveEmptyEntries);
             // we need to add GET back in because ServerHandshake doesn't include it
             RequestLine = "GET" + all[0];
-            for (int i = 1; i < all.Length; i++)
-            {
-                string[] split = all[i].Split(':');
-                if (split.Length == 2)
-                {
-                    Headers.Add(split[0].Trim(), split[1].Trim());
-                }
-            }
+            Headers = all.Skip(1)
+                         .Select(header => header.Split(':'))
+                         .Where(split => split.Length == 2)
+                         .ToDictionary(split => split[0].Trim(), split => split[1].Trim());
         }
     }
 }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs
@@ -17,7 +17,7 @@ namespace Mirror.SimpleWeb
         {
             string[] all = message.Split(lineSplitChars, StringSplitOptions.RemoveEmptyEntries);
             // we need to add GET back in because ServerHandshake doesn't include it
-            RequestLine = "GET" + all[0];
+            RequestLine = $"GET{all[0]}";
             Headers = all.Skip(1)
                          .Select(header => header.Split(':'))
                          .Where(split => split.Length == 2)

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs.meta
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Common/Request.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50b41ad63d4956a42a073bad5158fe09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
@@ -65,6 +65,7 @@ namespace Mirror.SimpleWeb
                 AcceptHandshake(stream, msg);
 
                 conn.request = new Request(msg);
+                conn.remoteAddress = conn.CalculateAddress();
 
                 return true;
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
@@ -87,7 +87,7 @@ namespace Mirror.SimpleWeb
                 int readCount = readCountOrFail.Value;
 
                 string msg = Encoding.ASCII.GetString(readBuffer.array, 0, readCount);
-                Log.Verbose(msg, false);
+                Log.Info($"GET{msg}", false);
 
                 return msg;
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
@@ -87,7 +87,9 @@ namespace Mirror.SimpleWeb
                 int readCount = readCountOrFail.Value;
 
                 string msg = Encoding.ASCII.GetString(readBuffer.array, 0, readCount);
-                Log.Info($"GET{msg}", false);
+                // GET isn't in the bytes we read here, so we need to add it back
+                msg = $"GET{msg}";
+                Log.Info(msg, false);
 
                 return msg;
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
@@ -63,6 +63,9 @@ namespace Mirror.SimpleWeb
             try
             {
                 AcceptHandshake(stream, msg);
+
+                conn.request = new Request(msg);
+
                 return true;
             }
             catch (ArgumentException e)

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/ServerHandshake.cs
@@ -89,7 +89,7 @@ namespace Mirror.SimpleWeb
                 string msg = Encoding.ASCII.GetString(readBuffer.array, 0, readCount);
                 // GET isn't in the bytes we read here, so we need to add it back
                 msg = $"GET{msg}";
-                Log.Info(msg, false);
+                Log.Info($"Client Handshake Message:\r\n{msg}", false);
 
                 return msg;
             }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/SimpleWebServer.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/SimpleWebServer.cs
@@ -60,6 +60,8 @@ namespace Mirror.SimpleWeb
 
         public string GetClientAddress(int connectionId) => server.GetClientAddress(connectionId);
 
+        public Request GetClientRequest(int connectionId) => server.GetClientRequest(connectionId);
+
         /// <summary>
         /// Processes all new messages
         /// </summary>

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/WebSocketServer.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/WebSocketServer.cs
@@ -245,15 +245,7 @@ namespace Mirror.SimpleWeb
                 return null;
             }
 
-            var headers = conn.request.Headers;
-            if (headers.TryGetValue("X-Forwarded-For", out var forwardFor))
-            {
-                var ips = forwardFor.ToString().Split(',');
-                var actualClientIP = ips[0];
-                return actualClientIP;
-            }
-
-            return conn.client.Client.RemoteEndPoint.ToString();
+            return conn.remoteAddress;
         }
 
         public Request GetClientRequest(int id)

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/WebSocketServer.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/WebSocketServer.cs
@@ -237,16 +237,36 @@ namespace Mirror.SimpleWeb
 
         public string GetClientAddress(int id)
         {
-            if (connections.TryGetValue(id, out Connection conn))
-                return conn.client.Client.RemoteEndPoint.ToString();
-            else
+            if (!connections.TryGetValue(id, out Connection conn))
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine($"[SimpleWebTransport] Cannot get address of connection {id} because connection was not found in dictionary.");
                 Console.ResetColor();
-
                 return null;
             }
+
+            var headers = conn.request.Headers;
+            if (headers.TryGetValue("X-Forwarded-For", out var forwardFor))
+            {
+                var ips = forwardFor.ToString().Split(',');
+                var actualClientIP = ips[0];
+                return actualClientIP;
+            }
+
+            return conn.client.Client.RemoteEndPoint.ToString();
+        }
+
+        public Request GetClientRequest(int id)
+        {
+            if (!connections.TryGetValue(id, out Connection conn))
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine($"[SimpleWebTransport] Cant get request of connection {id} because connection was not found in dictionary.");
+                Console.ResetColor();
+                return null;
+            }
+
+            return conn.request;
         }
     }
 }

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -291,6 +291,8 @@ namespace Mirror.SimpleWeb
 
         public override string ServerGetClientAddress(int connectionId) => server.GetClientAddress(connectionId);
 
+        public Request ServerGetClientRequest(int connectionId) => server.GetClientRequest(connectionId);
+
         // messages should always be processed in early update
         public override void ServerEarlyUpdate()
         {


### PR DESCRIPTION
When running behind a reverse proxy the IP endpoints will be that of the reverse proxy, not the client. Reverse proxies like Nginx set the ip if the host in a http header, the server can read this header during the handshake and store it so it knows the IP address of the client