### PR TITLE
fix: Weaver runtime fuse to ensure weaving succeeded before starting Server/Client

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -168,15 +168,6 @@ namespace Mirror
         /// <summary>Connect client to a NetworkServer by address.</summary>
         public static void Connect(string address)
         {
-            // safety: ensure Weaving succeded.
-            // if it silently failed, we would get lots of 'writer not found'
-            // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.Weaved())
-            {
-                Debug.LogError("NetworkClient won't start because Weaver either failed or didn't run.");
-                return;
-            }
-
             Initialize(false);
 
             AddTransportHandlers();
@@ -188,15 +179,6 @@ namespace Mirror
         /// <summary>Connect client to a NetworkServer by Uri.</summary>
         public static void Connect(Uri uri)
         {
-            // safety: ensure Weaving succeded.
-            // if it silently failed, we would get lots of 'writer not found'
-            // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.Weaved())
-            {
-                Debug.LogError("NetworkClient won't start because Weaving failed.");
-                return;
-            }
-
             Initialize(false);
 
             AddTransportHandlers();

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -159,6 +159,15 @@ namespace Mirror
         /// <summary>Connect client to a NetworkServer by address.</summary>
         public static void Connect(string address)
         {
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.State)
+            {
+                Debug.LogError("NetworkClient won't start because Weaving failed.");
+                return;
+            }
+
             Initialize(false);
 
             AddTransportHandlers();
@@ -170,6 +179,15 @@ namespace Mirror
         /// <summary>Connect client to a NetworkServer by Uri.</summary>
         public static void Connect(Uri uri)
         {
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.State)
+            {
+                Debug.LogError("NetworkClient won't start because Weaving failed.");
+                return;
+            }
+
             Initialize(false);
 
             AddTransportHandlers();

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -200,6 +200,15 @@ namespace Mirror
         // called from NetworkManager.FinishStartHost()
         public static void ConnectHost()
         {
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.Weaved())
+            {
+                Debug.LogError("NetworkClient won't start because Weaving failed.");
+                return;
+            }
+
             Initialize(true);
             connectState = ConnectState.Connected;
             HostMode.SetupConnections();

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -162,7 +162,7 @@ namespace Mirror
             // safety: ensure Weaving succeded.
             // if it silently failed, we would get lots of 'writer not found'
             // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.State)
+            if (!WeaverFuse.Weaved())
             {
                 Debug.LogError("NetworkClient won't start because Weaving failed.");
                 return;
@@ -182,7 +182,7 @@ namespace Mirror
             // safety: ensure Weaving succeded.
             // if it silently failed, we would get lots of 'writer not found'
             // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.State)
+            if (!WeaverFuse.Weaved())
             {
                 Debug.LogError("NetworkClient won't start because Weaving failed.");
                 return;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -164,7 +164,7 @@ namespace Mirror
             // and other random errors at runtime instead. this is cleaner.
             if (!WeaverFuse.Weaved())
             {
-                Debug.LogError("NetworkClient won't start because Weaving failed.");
+                Debug.LogError("NetworkClient won't start because Weaver either failed or didn't run.");
                 return;
             }
 

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -151,7 +151,7 @@ namespace Mirror
             if (!WeaverFuse.Weaved())
             {
                 // if it failed, throw an exception to early exit all Connect calls.
-                throw new Exception("NetworkClient won't start because Weaving failed.");
+                throw new Exception("NetworkClient won't start because Weaving failed or didn't run.");
             }
 
             // Debug.Log($"Client Connect: {address}");

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -145,6 +145,15 @@ namespace Mirror
         // initialize is called before every connect
         static void Initialize(bool hostMode)
         {
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.Weaved())
+            {
+                // if it failed, throw an exception to early exit all Connect calls.
+                throw new Exception("NetworkClient won't start because Weaving failed.");
+            }
+
             // Debug.Log($"Client Connect: {address}");
             Debug.Assert(Transport.active != null, "There was no active transport when calling NetworkClient.Connect, If you are calling Connect manually then make sure to set 'Transport.active' first");
 
@@ -200,15 +209,6 @@ namespace Mirror
         // called from NetworkManager.FinishStartHost()
         public static void ConnectHost()
         {
-            // safety: ensure Weaving succeded.
-            // if it silently failed, we would get lots of 'writer not found'
-            // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.Weaved())
-            {
-                Debug.LogError("NetworkClient won't start because Weaving failed.");
-                return;
-            }
-
             Initialize(true);
             connectState = ConnectState.Connected;
             HostMode.SetupConnections();

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -102,7 +102,7 @@ namespace Mirror
             // safety: ensure Weaving succeded.
             // if it silently failed, we would get lots of 'writer not found'
             // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.State)
+            if (!WeaverFuse.Weaved())
             {
                 Debug.LogError("NetworkServer won't start because Weaving failed.");
                 return;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -99,15 +99,6 @@ namespace Mirror
         /// <summary>Starts server and listens to incoming connections with max connections limit.</summary>
         public static void Listen(int maxConns)
         {
-            // safety: ensure Weaving succeded.
-            // if it silently failed, we would get lots of 'writer not found'
-            // and other random errors at runtime instead. this is cleaner.
-            if (!WeaverFuse.Weaved())
-            {
-                Debug.LogError("NetworkServer won't start because Weaver either failed or didn't run.");
-                return;
-            }
-
             Initialize();
             maxConnections = maxConns;
 
@@ -127,6 +118,15 @@ namespace Mirror
         {
             if (initialized)
                 return;
+
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.Weaved())
+            {
+                // if it failed, throw an exception to early exit all Listen calls.
+                throw new Exception("NetworkServer won't start because Weaver either failed or didn't run.");
+            }
 
             // Debug.Log($"NetworkServer Created version {Version.Current}");
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -125,7 +125,7 @@ namespace Mirror
             if (!WeaverFuse.Weaved())
             {
                 // if it failed, throw an exception to early exit all Listen calls.
-                throw new Exception("NetworkServer won't start because Weaver either failed or didn't run.");
+                throw new Exception("NetworkServer won't start because Weaving failed or didn't run.");
             }
 
             // Debug.Log($"NetworkServer Created version {Version.Current}");

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -99,6 +99,15 @@ namespace Mirror
         /// <summary>Starts server and listens to incoming connections with max connections limit.</summary>
         public static void Listen(int maxConns)
         {
+            // safety: ensure Weaving succeded.
+            // if it silently failed, we would get lots of 'writer not found'
+            // and other random errors at runtime instead. this is cleaner.
+            if (!WeaverFuse.State)
+            {
+                Debug.LogError("NetworkServer won't start because Weaving failed.");
+                return;
+            }
+
             Initialize();
             maxConnections = maxConns;
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -104,7 +104,7 @@ namespace Mirror
             // and other random errors at runtime instead. this is cleaner.
             if (!WeaverFuse.Weaved())
             {
-                Debug.LogError("NetworkServer won't start because Weaving failed.");
+                Debug.LogError("NetworkServer won't start because Weaver either failed or didn't run.");
                 return;
             }
 

--- a/Assets/Mirror/Core/WeaverFuse.cs
+++ b/Assets/Mirror/Core/WeaverFuse.cs
@@ -6,6 +6,6 @@ namespace Mirror
 {
     public static class WeaverFuse
     {
-        public static bool State => false;
+        public static bool Weaved() => false;
     }
 }

--- a/Assets/Mirror/Core/WeaverFuse.cs
+++ b/Assets/Mirror/Core/WeaverFuse.cs
@@ -1,0 +1,11 @@
+// safety fuse for weaver to flip.
+// runtime can check this to ensure weaving succeded.
+// otherwise running server/client would give lots of random 'writer not found' etc. errors.
+// this is much cleaner.
+namespace Mirror
+{
+    public static class WeaverFuse
+    {
+        public static bool State => false;
+    }
+}

--- a/Assets/Mirror/Core/WeaverFuse.cs
+++ b/Assets/Mirror/Core/WeaverFuse.cs
@@ -2,6 +2,10 @@
 // runtime can check this to ensure weaving succeded.
 // otherwise running server/client would give lots of random 'writer not found' etc. errors.
 // this is much cleaner.
+//
+// note that ILPostProcessor errors already block entering playmode.
+// however, issues could still stop the weaving from running at all.
+// WeaverFuse can check if it actually ran.
 namespace Mirror
 {
     public static class WeaverFuse

--- a/Assets/Mirror/Core/WeaverFuse.cs.meta
+++ b/Assets/Mirror/Core/WeaverFuse.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4de3dfbcbd2e41fcac947c04bcac52c9
+timeCreated: 1686319660

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -145,10 +145,6 @@ namespace Mirror.Weaver
 
         void ToggleWeaverFuse(ModuleDefinition moduleDefinition)
         {
-            Log.Warning("Weaver: toggled Fuse!");
-
-            // weaverTypes.WeaverFuseState.Resolve();
-
             // find WeaverFuse class
             TypeDefinition weaverFuse = moduleDefinition.GetType(GeneratedCodeNamespace, "WeaverFuse");
 

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -242,10 +242,7 @@ namespace Mirror.Weaver
                     //CurrentAssembly.Write(new WriterParameters{ WriteSymbols = true });
                 }
 
-                // finally, switch on the WeaverFuse for runtime check.
-                // TODO is this the Mirror assembly?
-
-                // switch the Weaver Fuse in Mirror.dll
+                // if weaving succeeded, switch on the Weaver Fuse in Mirror.dll
                 if (CurrentAssembly.Name.Name == MirrorAssemblyName)
                 {
                     ToggleWeaverFuse(moduleDefinition);

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -150,7 +150,6 @@ namespace Mirror.Weaver
 
             // find Weaved() function
             MethodDefinition func = weaverFuse.GetMethod("Weaved");
-            Log.Warning($"Fuse: {weaverFuse} : {func}");
 
             // change return 0 to return 1
             ILProcessor worker = func.Body.GetILProcessor();

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -143,15 +143,12 @@ namespace Mirror.Weaver
                 weaverTypes.Import<object>());
         }
 
-        void ToggleWeaverFuse(ModuleDefinition moduleDefinition)
+        void ToggleWeaverFuse()
         {
-            // find WeaverFuse class
-            TypeDefinition weaverFuse = moduleDefinition.GetType(GeneratedCodeNamespace, "WeaverFuse");
+            // // find Weaved() function
+            MethodDefinition func = weaverTypes.weaverFuseMethod.Resolve();
+            // // change return 0 to return 1
 
-            // find Weaved() function
-            MethodDefinition func = weaverFuse.GetMethod("Weaved");
-
-            // change return 0 to return 1
             ILProcessor worker = func.Body.GetILProcessor();
             func.Body.Instructions[0] = worker.Create(OpCodes.Ldc_I4_1);
         }
@@ -245,7 +242,7 @@ namespace Mirror.Weaver
                 // if weaving succeeded, switch on the Weaver Fuse in Mirror.dll
                 if (CurrentAssembly.Name.Name == MirrorAssemblyName)
                 {
-                    ToggleWeaverFuse(moduleDefinition);
+                    ToggleWeaverFuse();
                 }
 
                 return true;

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -53,6 +53,9 @@ namespace Mirror.Weaver
 
         public MethodReference readNetworkBehaviourGeneric;
 
+        public TypeReference weaverFuseType;
+        public MethodReference weaverFuseMethod;
+
         // attributes
         public TypeDefinition initializeOnLoadMethodAttribute;
         public TypeDefinition runtimeInitializeOnLoadMethodAttribute;
@@ -74,6 +77,9 @@ namespace Mirror.Weaver
 
             TypeReference ActionType = Import(typeof(Action<,>));
             ActionT_T = Resolvers.ResolveMethod(ActionType, assembly, Log, ".ctor", ref WeavingFailed);
+
+            weaverFuseType = Import(typeof(WeaverFuse));
+            weaverFuseMethod = Resolvers.ResolveMethod(weaverFuseType, assembly, Log, "Weaved", ref WeavingFailed);
 
             TypeReference NetworkServerType = Import(typeof(NetworkServer));
             NetworkServerGetActive = Resolvers.ResolveMethod(NetworkServerType, assembly, Log, "get_active", ref WeavingFailed);

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+
+namespace Mirror.Weaver.Tests
+{
+    public class WeaverFuseTests
+    {
+        [Test]
+        public void WeavingSucceded()
+        {
+            // .State returns false by default.
+            // Weaver overwrites this to true.
+            Assert.That(WeaverFuse.State, Is.True);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
@@ -7,7 +7,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void WeavingSucceded()
         {
-            // .State returns false by default.
+            // the fuse returns false by default.
             // Weaver overwrites this to true.
             Assert.That(WeaverFuse.Weaved(), Is.True);
         }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs
@@ -9,7 +9,7 @@ namespace Mirror.Weaver.Tests
         {
             // .State returns false by default.
             // Weaver overwrites this to true.
-            Assert.That(WeaverFuse.State, Is.True);
+            Assert.That(WeaverFuse.Weaved(), Is.True);
         }
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverFuseTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a02e0f4cd7c34bf3823b2bc82b82dc3f
+timeCreated: 1686319774


### PR DESCRIPTION
allows for much more pleasant debugging.
weaver failures can be detected easily at runtime, with a clean stop.
instead of throwing thousands of 'no writer found ...' error later on

ILPostProcessor weaver errors automatically block entering playmode:
<img width="1022" alt="2023-06-11 - 08-33-33@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/a4c53cad-7657-439a-8935-c86b68fa5871">

However, this can ensure that ILPostProcessor actually ran.
It's also useful for CompilationFinishedHook, where weaver errors would not block entering play mode.


Tested in uMMORPG:
<img width="850" alt="2023-06-11 - 08-45-28@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/abeaa887-e98d-4897-b766-6d7bebdce23f">
