### PR TITLE
fix: NetworkClient unbatcher is now reset in host mode connect as well [credit: BigBoxVR]

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -107,7 +107,7 @@ namespace Mirror
         internal static readonly Dictionary<ulong, NetworkIdentity> spawnableObjects =
             new Dictionary<ulong, NetworkIdentity>();
 
-        static Unbatcher unbatcher = new Unbatcher();
+        internal static Unbatcher unbatcher = new Unbatcher();
 
         // interest management component (optional)
         // only needed for SetHostVisibility
@@ -147,6 +147,12 @@ namespace Mirror
         {
             // Debug.Log($"Client Connect: {address}");
             Debug.Assert(Transport.active != null, "There was no active transport when calling NetworkClient.Connect, If you are calling Connect manually then make sure to set 'Transport.active' first");
+
+            // reset unbatcher in case any batches from last session remain.
+            // need to do this in Initialize() so it runs for the host as well.
+            // fixes host mode scene transition receiving data from previous scene.
+            // credits: BigBoxVR
+            unbatcher = new Unbatcher();
 
             // reset time interpolation on every new connect.
             // ensures last sessions' state is cleared before starting again.
@@ -226,9 +232,6 @@ namespace Mirror
             {
                 // reset network time stats
                 NetworkTime.ResetStatics();
-
-                // reset unbatcher in case any batches from last session remain.
-                unbatcher = new Unbatcher();
 
                 // the handler may want to send messages to the client
                 // thus we should set the connected state before calling the handler


### PR DESCRIPTION
Fixes a bug where host mode scene transitions would still receive a previous scene's data.
credit: BigBoxVR

TODO

- [ ] working test coverage without 'internal' workaround
- [ ] check if all tests still pass
- [ ] remove 'new unbatcher' from OnTransportConnected. one place is enough.
- [ ] test scene transisions