### PR TITLE
feature: Weaver adds 'bool Weaved()' to each NetworkBehaviour, which can be checked at runtime

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -1351,5 +1351,9 @@ namespace Mirror
 
         /// <summary>Stop event, only called for objects the client has authority over.</summary>
         public virtual void OnStopAuthority() {}
+
+        // Weaver injects this into inheriting classes to return true.
+        // allows runtime & tests to check if a type was weaved.
+        public virtual bool MirrorProcessed() { return false; }
     }
 }

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -1354,6 +1354,7 @@ namespace Mirror
 
         // Weaver injects this into inheriting classes to return true.
         // allows runtime & tests to check if a type was weaved.
-        public virtual bool MirrorProcessed() { return false; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual bool MirrorProcessed() => false;
     }
 }

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -1355,6 +1355,6 @@ namespace Mirror
         // Weaver injects this into inheriting classes to return true.
         // allows runtime & tests to check if a type was weaved.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual bool MirrorProcessed() => false;
+        public virtual bool Weaved() => false;
     }
 }

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -218,8 +218,12 @@ namespace Mirror.Weaver
             if (!WasProcessed(td))
             {
                 // add a function:
-                // public bool MirrorProcessed() { return true; }
-                MethodDefinition versionMethod = new MethodDefinition(ProcessedFunctionName, MethodAttributes.Public, weaverTypes.Import(typeof(bool)));
+                //   public override bool MirrorProcessed() { return true; }
+                // ReuseSlot means 'override'.
+                MethodDefinition versionMethod = new MethodDefinition(
+                    ProcessedFunctionName,
+                    MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.ReuseSlot,
+                    weaverTypes.Import(typeof(bool)));
                 ILProcessor worker = versionMethod.Body.GetILProcessor();
                 worker.Emit(OpCodes.Ldc_I4_1);
                 worker.Emit(OpCodes.Ret);

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -205,7 +205,7 @@ namespace Mirror.Weaver
         }
 
         #region mark / check type as processed
-        public const string ProcessedFunctionName = "MirrorProcessed";
+        public const string ProcessedFunctionName = "Weaved";
 
         // by adding an empty MirrorProcessed() function
         public static bool WasProcessed(TypeDefinition td)

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -207,12 +207,14 @@ namespace Mirror.Weaver
         #region mark / check type as processed
         public const string ProcessedFunctionName = "Weaved";
 
-        // by adding an empty MirrorProcessed() function
+        // check if the type has a "Weaved" function already
         public static bool WasProcessed(TypeDefinition td)
         {
             return td.GetMethod(ProcessedFunctionName) != null;
         }
 
+        // add the Weaved() function which returns true.
+        // can be called at runtime and from tests to check if weaving succeeded.
         public void MarkAsProcessed(TypeDefinition td)
         {
             if (!WasProcessed(td))

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -217,8 +217,11 @@ namespace Mirror.Weaver
         {
             if (!WasProcessed(td))
             {
-                MethodDefinition versionMethod = new MethodDefinition(ProcessedFunctionName, MethodAttributes.Private, weaverTypes.Import(typeof(void)));
+                // add a function:
+                // public bool MirrorProcessed() { return true; }
+                MethodDefinition versionMethod = new MethodDefinition(ProcessedFunctionName, MethodAttributes.Public, weaverTypes.Import(typeof(bool)));
                 ILProcessor worker = versionMethod.Body.GetILProcessor();
+                worker.Emit(OpCodes.Ldc_I4_1);
                 worker.Emit(OpCodes.Ret);
                 td.Methods.Add(versionMethod);
             }
@@ -531,7 +534,7 @@ namespace Mirror.Weaver
                 {
                     writeFunc = writers.GetWriteFunc(syncVar.FieldType, ref WeavingFailed);
                 }
-                
+
                 if (writeFunc != null)
                 {
                     worker.Emit(OpCodes.Call, writeFunc);


### PR DESCRIPTION
Previously Weaver would add:
```cs
private void MirrorProcessed() {}
```

This PR changes adds a base function to NetworkBehaviour:
```cs
public virtual void Weaved() { return false; }
```
And Weaver now tags processed component with:
```cs
public override void Weaved() { return true; }
```

Which means that we can now check at runtime:
```cs
if (!Monster.Weaved()) throw;
Assert.That(Monster.Weaved(), Is.True);
etc.
```

