### PR TITLE
feature: ConnectionQuality Heuristic + Callback + GUI

### DIFF
--- a/Assets/Mirror/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirror/Components/NetworkPingDisplay.cs
@@ -13,7 +13,7 @@ namespace Mirror
     {
         public Color color = Color.white;
         public int padding = 2;
-        public int width = 150;
+        public int width = 180;
         public int height = 25;
 
         void OnGUI()
@@ -21,12 +21,17 @@ namespace Mirror
             // only while client is active
             if (!NetworkClient.active) return;
 
-            // show rtt in bottom right corner, right aligned
+            // show stats in bottom right corner, right aligned
             GUI.color = color;
             Rect rect = new Rect(Screen.width - width - padding, Screen.height - height - padding, width, height);
+            GUILayout.BeginArea(rect);
             GUIStyle style = GUI.skin.GetStyle("Label");
             style.alignment = TextAnchor.MiddleRight;
-            GUI.Label(rect, $"RTT: {Math.Round(NetworkTime.rtt * 1000)}ms", style);
+            GUILayout.BeginHorizontal(style);
+                GUILayout.Label($"RTT: {Math.Round(NetworkTime.rtt * 1000)}ms");
+                GUILayout.Label($"Q: {NetworkClient.connectionQuality}");
+            GUILayout.EndHorizontal();
+            GUILayout.EndArea();
             GUI.color = Color.white;
         }
     }

--- a/Assets/Mirror/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirror/Components/NetworkPingDisplay.cs
@@ -29,7 +29,7 @@ namespace Mirror
             style.alignment = TextAnchor.MiddleRight;
             GUILayout.BeginHorizontal(style);
                 GUILayout.Label($"RTT: {Math.Round(NetworkTime.rtt * 1000)}ms");
-                GUI.color = ConnectionQualityHeuristics.ColorCode(NetworkClient.connectionQuality);
+                GUI.color = NetworkClient.connectionQuality.ColorCode();
                 GUILayout.Label($"Q: {NetworkClient.connectionQuality}");
             GUILayout.EndHorizontal();
             GUILayout.EndArea();

--- a/Assets/Mirror/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirror/Components/NetworkPingDisplay.cs
@@ -29,6 +29,7 @@ namespace Mirror
             style.alignment = TextAnchor.MiddleRight;
             GUILayout.BeginHorizontal(style);
                 GUILayout.Label($"RTT: {Math.Round(NetworkTime.rtt * 1000)}ms");
+                GUI.color = ConnectionQualityHeuristics.ColorCode(NetworkClient.connectionQuality);
                 GUILayout.Label($"Q: {NetworkClient.connectionQuality}");
             GUILayout.EndHorizontal();
             GUILayout.EndArea();

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -1,0 +1,66 @@
+// standalone, Unity-independent connection-quality algorithm & enum.
+// don't need to use this directly, it's built into Mirror's NetworkClient.
+namespace Mirror
+{
+    public enum ConnectionQuality : byte
+    {
+        EXCELLENT,
+        GOOD,
+        FAIR,
+        POOR,
+        ESTIMATING,
+    }
+
+    // provide different heuristics for users to choose from.
+    // simple heuristics to get started.
+    // this will be iterated on over time based on user feedback.
+    public static class ConnectionQualityHeuristics
+    {
+        // straight forward estimation
+        //   rtt: average round trip time in seconds.
+        //   jitter: average latency variance.
+        public static ConnectionQuality Simple(double rtt, double jitter)
+        {
+            // 50 ms ping = 100 ms rtt, and 10ms jitter
+            if (rtt <= 0.100 && jitter <= 0.10)
+                return ConnectionQuality.EXCELLENT;
+
+            // 100 ms ping = 200 ms rtt, and 20ms jitter
+            if (rtt <= 0.200 && jitter <= 0.20)
+                return ConnectionQuality.GOOD;
+
+            // 200 ms ping = 400 ms rtt, and 50ms jitter
+            if (rtt <= 0.400 && jitter <= 0.50)
+                return ConnectionQuality.FAIR;
+
+            // everything else is poor
+            return ConnectionQuality.POOR;
+        }
+
+        // snapshot interpolation based estimation.
+        // snap. interp. adjusts buffer time based on connection quality.
+        // based on this, we can measure how far away we are from the ideal.
+        // the returned quality will always directly correlate with gameplay.
+        // => requires SnapshotInterpolation dynamicAdjustment to be enabled!
+        public static ConnectionQuality Pragmatic(double targetBufferTime, double currentBufferTime)
+        {
+            // buffer time is set by the game developer.
+            // estimating in multiples is a great way to be game independent.
+            // for example, a fast paced shooter and a slow paced RTS will both
+            // have poor connection if the multiplier is >10.
+            double multiplier = currentBufferTime / targetBufferTime;
+
+            // dynamic adjustment may even reduce multiplier on great connections
+            if (multiplier <= 1.0) return ConnectionQuality.EXCELLENT;
+
+            // 150% multiplier: 50ms => 75ms is still good
+            if (multiplier <= 1.5) return ConnectionQuality.GOOD;
+
+            // 200% multiplier: 50ms => 100ms is still fair
+            if (multiplier <= 2.0) return ConnectionQuality.FAIR;
+
+            // anything else is poor
+            return ConnectionQuality.POOR;
+        }
+    }
+}

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -36,19 +36,10 @@ namespace Mirror
         //   jitter: average latency variance.
         public static ConnectionQuality Simple(double rtt, double jitter)
         {
-            // 50 ms ping = 100 ms rtt, and 10ms jitter
-            if (rtt <= 0.100 && jitter <= 0.10)
-                return ConnectionQuality.EXCELLENT;
-
-            // 100 ms ping = 200 ms rtt, and 20ms jitter
-            if (rtt <= 0.200 && jitter <= 0.20)
-                return ConnectionQuality.GOOD;
-
-            // 200 ms ping = 400 ms rtt, and 50ms jitter
-            if (rtt <= 0.400 && jitter <= 0.50)
-                return ConnectionQuality.FAIR;
-
-            // everything else is poor
+            // estimations use round trip time, which is roughly 2x ping.
+            if (rtt <= 0.100 && jitter <= 0.10) return ConnectionQuality.EXCELLENT;
+            if (rtt <= 0.200 && jitter <= 0.20) return ConnectionQuality.GOOD;
+            if (rtt <= 0.400 && jitter <= 0.50) return ConnectionQuality.FAIR;
             return ConnectionQuality.POOR;
         }
 

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -36,7 +36,6 @@ namespace Mirror
         //   jitter: average latency variance.
         public static ConnectionQuality Simple(double rtt, double jitter)
         {
-            // estimations use round trip time, which is roughly 2x ping.
             if (rtt <= 0.100 && jitter <= 0.10) return ConnectionQuality.EXCELLENT;
             if (rtt <= 0.200 && jitter <= 0.20) return ConnectionQuality.GOOD;
             if (rtt <= 0.400 && jitter <= 0.50) return ConnectionQuality.FAIR;

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -4,14 +4,13 @@ using UnityEngine;
 
 namespace Mirror
 {
-    // Empirical values, based on Tanks demo + LatencySimulation.
     public enum ConnectionQuality : byte
     {
-        EXCELLENT,
-        GOOD,
-        FAIR,
-        POOR,
-        ESTIMATING,
+        EXCELLENT,  // ideal experience for high level competitors
+        GOOD,       // very playable for everyone but high level competitors
+        FAIR,       // very noticeable latency, not very enjoyable anymore
+        POOR,       // unplayable
+        ESTIMATING, // still estimating
     }
 
     // provide different heuristics for users to choose from.

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -1,5 +1,7 @@
 // standalone, Unity-independent connection-quality algorithm & enum.
 // don't need to use this directly, it's built into Mirror's NetworkClient.
+using UnityEngine;
+
 namespace Mirror
 {
     public enum ConnectionQuality : byte
@@ -16,6 +18,19 @@ namespace Mirror
     // this will be iterated on over time based on user feedback.
     public static class ConnectionQualityHeuristics
     {
+        // convenience function to color code Connection Quality
+        public static Color ColorCode(this ConnectionQuality quality)
+        {
+            switch (quality)
+            {
+                case ConnectionQuality.EXCELLENT:  return Color.green;
+                case ConnectionQuality.GOOD:       return Color.yellow;
+                case ConnectionQuality.FAIR:       return Color.magenta;
+                case ConnectionQuality.POOR:       return Color.red;
+                default:                           return Color.gray;
+            }
+        }
+
         // straight forward estimation
         //   rtt: average round trip time in seconds.
         //   jitter: average latency variance.

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -25,7 +25,7 @@ namespace Mirror
             {
                 case ConnectionQuality.EXCELLENT:  return Color.green;
                 case ConnectionQuality.GOOD:       return Color.yellow;
-                case ConnectionQuality.FAIR:       return Color.magenta;
+                case ConnectionQuality.FAIR: return new Color(1.0f, 0.647f, 0.0f);
                 case ConnectionQuality.POOR:       return Color.red;
                 default:                           return Color.gray;
             }

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -26,7 +26,7 @@ namespace Mirror
             {
                 case ConnectionQuality.EXCELLENT:  return Color.green;
                 case ConnectionQuality.GOOD:       return Color.yellow;
-                case ConnectionQuality.FAIR: return new Color(1.0f, 0.647f, 0.0f);
+                case ConnectionQuality.FAIR:       return new Color(1.0f, 0.647f, 0.0f);
                 case ConnectionQuality.POOR:       return Color.red;
                 default:                           return Color.gray;
             }

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 namespace Mirror
 {
+    // Empirical values, based on Tanks demo + LatencySimulation.
     public enum ConnectionQuality : byte
     {
         EXCELLENT,

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -55,14 +55,11 @@ namespace Mirror
             // have poor connection if the multiplier is >10.
             double multiplier = currentBufferTime / targetBufferTime;
 
-            // 20% off multiplier is still great
-            if (multiplier <= 1.2) return ConnectionQuality.EXCELLENT;
-
-            // 75% off multiplier is still good
-            if (multiplier <= 1.75) return ConnectionQuality.GOOD;
-
-            // 100% off multiplier is still fair
-            if (multiplier <= 2.0) return ConnectionQuality.FAIR;
+            // empirically measured with Tanks demo + LatencySimulation.
+            // it's not obvious to estimate on paper.
+            if (multiplier <= 1.15) return ConnectionQuality.EXCELLENT;
+            if (multiplier <= 1.25) return ConnectionQuality.GOOD;
+            if (multiplier <= 1.50) return ConnectionQuality.FAIR;
 
             // anything else is poor
             return ConnectionQuality.POOR;

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -65,13 +65,13 @@ namespace Mirror
             // have poor connection if the multiplier is >10.
             double multiplier = currentBufferTime / targetBufferTime;
 
-            // dynamic adjustment may even reduce multiplier on great connections
-            if (multiplier <= 1.0) return ConnectionQuality.EXCELLENT;
+            // 20% off multiplier is still great
+            if (multiplier <= 1.2) return ConnectionQuality.EXCELLENT;
 
-            // 150% multiplier: 50ms => 75ms is still good
-            if (multiplier <= 1.5) return ConnectionQuality.GOOD;
+            // 75% off multiplier is still good
+            if (multiplier <= 1.75) return ConnectionQuality.GOOD;
 
-            // 200% multiplier: 50ms => 100ms is still fair
+            // 100% off multiplier is still fair
             if (multiplier <= 2.0) return ConnectionQuality.FAIR;
 
             // anything else is poor

--- a/Assets/Mirror/Core/ConnectionQuality.cs
+++ b/Assets/Mirror/Core/ConnectionQuality.cs
@@ -18,7 +18,7 @@ namespace Mirror
     // this will be iterated on over time based on user feedback.
     public static class ConnectionQualityHeuristics
     {
-        // convenience function to color code Connection Quality
+        // convenience extension to color code Connection Quality
         public static Color ColorCode(this ConnectionQuality quality)
         {
             switch (quality)

--- a/Assets/Mirror/Core/ConnectionQuality.cs.meta
+++ b/Assets/Mirror/Core/ConnectionQuality.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff663b880e33e4606b545c8b497041c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 7453abfe9e8b2c04a8a47eb536fe21eb, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -116,6 +116,11 @@ namespace Mirror
         // scene loading
         public static bool isLoadingScene;
 
+        // connection quality
+        // this is set by a virtual function in NetworkManager,
+        // which allows users to overwrite it with their own estimations.
+        public static ConnectionQuality connectionQuality = ConnectionQuality.ESTIMATING;
+
         // initialization //////////////////////////////////////////////////////
         static void AddTransportHandlers()
         {

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -248,7 +248,8 @@ namespace Mirror
         {
             if (!NetworkClient.active) return;
 
-            NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
+            // NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
+            NetworkClient.connectionQuality = ConnectionQualityHeuristics.Simple(NetworkTime.rtt, NetworkTime.rttVar);
         }
 
         // keep the online scene change check in a separate function.

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -121,6 +121,11 @@ namespace Mirror
         [Header("Snapshot Interpolation")]
         public SnapshotInterpolationSettings snapshotSettings = new SnapshotInterpolationSettings();
 
+        [Header("Connection Quality")]
+        public float connectionQualityUpdateInterval = 3;
+        double lastConnectionQualityUpdate;
+        ConnectionQuality lastConnectionQuality = ConnectionQuality.ESTIMATING;
+
         [Header("Debug")]
         public bool timeInterpolationGui = false;
 
@@ -243,12 +248,15 @@ namespace Mirror
         }
 
         // Connection Quality //////////////////////////////////////////////////
-        ConnectionQuality lastConnectionQuality = ConnectionQuality.ESTIMATING;
-
         // uses 'pragmatic' version based on snapshot interpolation by default.
         void UpdateConnectionQuality()
         {
             if (!NetworkClient.active) return;
+
+            // only recalculate every few seconds
+            // we don't want to fire Good->Bad->Good->Bad hundreds of times per second.
+            if (NetworkTime.time < lastConnectionQualityUpdate + connectionQualityUpdateInterval) return;
+            lastConnectionQualityUpdate = NetworkTime.time;
 
             // recaclulate connection quality
             CalculateConnectionQuality();

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -242,6 +242,9 @@ namespace Mirror
             UpdateConnectionQuality();
         }
 
+        // Connection Quality //////////////////////////////////////////////////
+        ConnectionQuality previousConnectionQuality = ConnectionQuality.ESTIMATING;
+
         // uses 'pragmatic' version based on snapshot interpolation by default.
         void UpdateConnectionQuality()
         {
@@ -249,6 +252,13 @@ namespace Mirror
 
             // recaclulate connection quality
             CalculateConnectionQuality();
+
+            // call event if changed
+            if (NetworkClient.connectionQuality != previousConnectionQuality)
+            {
+                OnConnectionQualityChanged(previousConnectionQuality, NetworkClient.connectionQuality);
+                previousConnectionQuality = NetworkClient.connectionQuality;
+            }
         }
 
         // users can overwrite this to run their own connection quality estimation.
@@ -257,6 +267,14 @@ namespace Mirror
             // NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
             NetworkClient.connectionQuality = ConnectionQualityHeuristics.Simple(NetworkTime.rtt, NetworkTime.rttVar);
         }
+
+        // users can overwrite this to display connection quality warnings, etc.
+        protected virtual void OnConnectionQualityChanged(ConnectionQuality previous, ConnectionQuality current)
+        {
+            // Debug.Log($"ConnectionQuality changed from {previous} to {current}");
+        }
+
+        ////////////////////////////////////////////////////////////////////////
 
         // keep the online scene change check in a separate function.
         // only change scene if the requested online scene is not blank, and is not already loaded.

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -279,7 +279,7 @@ namespace Mirror
         // users can overwrite this to display connection quality warnings, etc.
         protected virtual void OnConnectionQualityChanged(ConnectionQuality previous, ConnectionQuality current)
         {
-            Debug.Log($"[Mirror] ConnectionQuality changed from {previous} to {current}");
+            Debug.Log($"[Mirror] Connection Quality changed from {previous} to {current}");
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -242,12 +242,18 @@ namespace Mirror
             UpdateConnectionQuality();
         }
 
-        // users can overwrite this to run their own connection quality estimation.
         // uses 'pragmatic' version based on snapshot interpolation by default.
-        protected virtual void UpdateConnectionQuality()
+        void UpdateConnectionQuality()
         {
             if (!NetworkClient.active) return;
 
+            // recaclulate connection quality
+            CalculateConnectionQuality();
+        }
+
+        // users can overwrite this to run their own connection quality estimation.
+        protected virtual void CalculateConnectionQuality()
+        {
             // NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
             NetworkClient.connectionQuality = ConnectionQualityHeuristics.Simple(NetworkTime.rtt, NetworkTime.rttVar);
         }

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -122,7 +122,7 @@ namespace Mirror
         public SnapshotInterpolationSettings snapshotSettings = new SnapshotInterpolationSettings();
 
         [Header("Connection Quality")]
-        public float connectionQualityUpdateInterval = 3;
+        public float connectionQualityInterval = 3;
         double lastConnectionQualityUpdate;
         ConnectionQuality lastConnectionQuality = ConnectionQuality.ESTIMATING;
 
@@ -255,7 +255,7 @@ namespace Mirror
 
             // only recalculate every few seconds
             // we don't want to fire Good->Bad->Good->Bad hundreds of times per second.
-            if (NetworkTime.time < lastConnectionQualityUpdate + connectionQualityUpdateInterval) return;
+            if (NetworkTime.time < lastConnectionQualityUpdate + connectionQualityInterval) return;
             lastConnectionQualityUpdate = NetworkTime.time;
 
             // recaclulate connection quality

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -243,7 +243,7 @@ namespace Mirror
         }
 
         // Connection Quality //////////////////////////////////////////////////
-        ConnectionQuality previousConnectionQuality = ConnectionQuality.ESTIMATING;
+        ConnectionQuality lastConnectionQuality = ConnectionQuality.ESTIMATING;
 
         // uses 'pragmatic' version based on snapshot interpolation by default.
         void UpdateConnectionQuality()
@@ -254,10 +254,10 @@ namespace Mirror
             CalculateConnectionQuality();
 
             // call event if changed
-            if (NetworkClient.connectionQuality != previousConnectionQuality)
+            if (NetworkClient.connectionQuality != lastConnectionQuality)
             {
-                OnConnectionQualityChanged(previousConnectionQuality, NetworkClient.connectionQuality);
-                previousConnectionQuality = NetworkClient.connectionQuality;
+                OnConnectionQualityChanged(lastConnectionQuality, NetworkClient.connectionQuality);
+                lastConnectionQuality = NetworkClient.connectionQuality;
             }
         }
 

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -239,6 +239,16 @@ namespace Mirror
         public virtual void LateUpdate()
         {
             UpdateScene();
+            UpdateConnectionQuality();
+        }
+
+        // users can overwrite this to run their own connection quality estimation.
+        // uses 'pragmatic' version based on snapshot interpolation by default.
+        protected virtual void UpdateConnectionQuality()
+        {
+            if (!NetworkClient.active) return;
+
+            NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
         }
 
         // keep the online scene change check in a separate function.

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -279,7 +279,7 @@ namespace Mirror
         // users can overwrite this to display connection quality warnings, etc.
         protected virtual void OnConnectionQualityChanged(ConnectionQuality previous, ConnectionQuality current)
         {
-            // Debug.Log($"ConnectionQuality changed from {previous} to {current}");
+            Debug.Log($"[Mirror] ConnectionQuality changed from {previous} to {current}");
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
@@ -531,7 +531,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   color: {r: 1, g: 1, b: 1, a: 1}
   padding: 2
-  width: 150
+  width: 180
   height: 25
 --- !u!1 &1458789072
 GameObject:


### PR DESCRIPTION
ConnectionQuality enum:
```cs
public enum ConnectionQuality : byte
{
    EXCELLENT,
    GOOD,
    FAIR,
    POOR,
    ESTIMATING,
}
```

Several Heuristics:
```cs
public static ConnectionQuality Simple(double rtt, double jitter)
{
    // estimations use round trip time, which is roughly 2x ping.
    if (rtt <= 0.100 && jitter <= 0.10) return ConnectionQuality.EXCELLENT;
    if (rtt <= 0.200 && jitter <= 0.20) return ConnectionQuality.GOOD;
    if (rtt <= 0.400 && jitter <= 0.50) return ConnectionQuality.FAIR;
    return ConnectionQuality.POOR;
}

// snapshot interpolation based estimation.
public static ConnectionQuality Pragmatic(double targetBufferTime, double currentBufferTime)
{
    double multiplier = currentBufferTime / targetBufferTime;
    if (multiplier <= 1.2) return ConnectionQuality.EXCELLENT;
    if (multiplier <= 1.75) return ConnectionQuality.GOOD;
    if (multiplier <= 2.0) return ConnectionQuality.FAIR;
    return ConnectionQuality.POOR;
}
```

Color coding for convenience:
```cs
public static Color ColorCode(this ConnectionQuality quality)
        {
            switch (quality)
            {
                case ConnectionQuality.EXCELLENT:  return Color.green;
                case ConnectionQuality.GOOD:       return Color.yellow;
                case ConnectionQuality.FAIR:       return Color.magenta;
                case ConnectionQuality.POOR:       return Color.red;
                default:                           return Color.gray;
            }
        }
```

Connection Quality is stored in NetworkClient.connectionQuality:
```cs
public static ConnectionQuality connectionQuality = ConnectionQuality.ESTIMATING;
```

NetworkManager has a virtual to refresh this. Users can overwrite with their own heuristics:
```cs
protected virtual void CalculateConnectionQuality()
{
    NetworkClient.connectionQuality = ConnectionQualityHeuristics.Pragmatic(NetworkClient.initialBufferTime, NetworkClient.bufferTime);
    // NetworkClient.connectionQuality = ConnectionQualityHeuristics.Simple(NetworkTime.rtt, NetworkTime.rttVar);
}
```

NetworkManager has a callback for when it changed. Users can use this to display warnings etc.:
```cs
protected virtual void OnConnectionQualityChanged(ConnectionQuality previous, ConnectionQuality current)
{
    // Debug.Log($"ConnectionQuality changed from {previous} to {current}");
}
```

**NetworkPingDisplay** now shows it too (bottom right):
<img width="1358" alt="2023-06-25 - connection quality, gui, callback" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/341784ae-5f16-4689-8857-47a6eafbb0fa">

Documentation:
https://mirror-networking.gitbook.io/docs/manual/general/connection-quality
