### PR TITLE
fix: PrepareToSpawnSceneObjects checks netId instead of activeSelf [fixes: #3541]

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1194,6 +1194,7 @@ namespace Mirror
             {
                 // add all unspawned NetworkIdentities to spawnable objects
                 // need to check netId to make sure object is not spawned
+                // fixes: https://github.com/MirrorNetworking/Mirror/issues/3541
                 // PrepareToSpawnSceneObjects may be called multiple times in case
                 // the ObjectSpawnStarted message is received multiple times.
                 if (Utils.IsSceneObject(identity) &&

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1193,11 +1193,11 @@ namespace Mirror
             foreach (NetworkIdentity identity in allIdentities)
             {
                 // add all unspawned NetworkIdentities to spawnable objects
-                // need to ensure it's not active yet because
+                // need to check netId to make sure object is not spawned
                 // PrepareToSpawnSceneObjects may be called multiple times in case
                 // the ObjectSpawnStarted message is received multiple times.
                 if (Utils.IsSceneObject(identity) &&
-                    !identity.gameObject.activeSelf)
+                    identity.netId == 0)
                 {
                     if (spawnableObjects.TryGetValue(identity.sceneId, out NetworkIdentity existingIdentity))
                     {


### PR DESCRIPTION
fixes: https://github.com/MirrorNetworking/Mirror/issues/3541

Should be safe to remove this extra check complete, it is safe to add spawned object to `spawnableObjects`. For now this just changes it to NetId to ensure that the object really is unspawned and not just enabled