### PR TITLE
fix: 2019 tests work again

### DIFF
--- a/Assets/Mirror/Editor/Weaver/EntryPoint/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/EntryPoint/CompilationFinishedHook.cs
@@ -75,8 +75,9 @@ namespace Mirror.Weaver
                 return;
             }
 
-            // Should not run on the editor only assemblies
-            if (assemblyPath.Contains("-Editor") || assemblyPath.Contains(".Editor"))
+            // Should not run on the editor only assemblies (test ones still need to be weaved)
+            if (assemblyPath.Contains("-Editor") || 
+                (assemblyPath.Contains(".Editor") && !assemblyPath.Contains(".Tests")))
             {
                 return;
             }


### PR DESCRIPTION
We excluded editor assemblies from weaving which is now an issue since tests use an assembly matching the "is editor assembly" check

This only affects 2019 since newer unity versions use the ILPostProcessor which does not have such a check