### PR TITLE
fix: #3550 NetworkBehaviour on ... requires a NetworkIdentity.

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -296,17 +296,18 @@ namespace Mirror
         protected virtual void OnValidate()
         {
             // we now allow child NetworkBehaviours.
-            // we can not [RequireComponent(typeof(NetworkIdentity))] anymore.
-            // instead, we need to ensure a NetworkIdentity is somewhere in the
-            // parents.
-            // only run this in Editor. don't add more runtime overhead.
+            // we cannot [RequireComponent(typeof(NetworkIdentity))] anymore.
+            // NetworkBehaviour is dependable from NetworkIdentity, so
+            // if any NetworkIdentity validation is required it should be done in NetworkIdentity class
+            // And if any other class needs NetworkBehaviour, it should not get it directly,
+            // but ask for it from NetworkIdentity
 
-#if UNITY_EDITOR
-            if(!NetworkServer.GetNetworkIdentity(gameObject, out _))
-            {
-                Debug.LogError($"{GetType()} on {name} requires a NetworkIdentity. Please add a NetworkIdentity component to {name} or it's parents.");
-            }
-#endif
+            //#if UNITY_EDITOR
+            //if(!NetworkServer.GetNetworkIdentity(gameObject, out _))
+            //{
+            //    Debug.LogError($"{GetType()} on {name} requires a NetworkIdentity. Please add a NetworkIdentity component to {name} or it's parents.");
+            //}
+            //#endif
         }
 
         // pass full function name to avoid ClassA.Func <-> ClassB.Func collisions

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -302,8 +302,7 @@ namespace Mirror
             // only run this in Editor. don't add more runtime overhead.
 
 #if UNITY_EDITOR
-            if (GetComponent<NetworkIdentity>() == null &&
-                GetComponentInParent<NetworkIdentity>(true) == null)
+            if(!NetworkServer.GetNetworkIdentity(gameObject, out _))
             {
                 Debug.LogError($"{GetType()} on {name} requires a NetworkIdentity. Please add a NetworkIdentity component to {name} or it's parents.");
             }

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -303,11 +303,7 @@ namespace Mirror
 
 #if UNITY_EDITOR
             if (GetComponent<NetworkIdentity>() == null &&
-#if UNITY_2021_OR_NEWER
                 GetComponentInParent<NetworkIdentity>(true) == null)
-#else
-                GetComponentInParent<NetworkIdentity>() == null)
-#endif
             {
                 Debug.LogError($"{GetType()} on {name} requires a NetworkIdentity. Please add a NetworkIdentity component to {name} or it's parents.");
             }

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -840,12 +840,16 @@ namespace Mirror
 
         internal static bool GetNetworkIdentity(GameObject go, out NetworkIdentity identity)
         {
-            if (!go.TryGetComponent(out identity))
-            {
-                Debug.LogError($"GameObject {go.name} doesn't have NetworkIdentity.");
-                return false;
-            }
-            return true;
+            identity = go.GetComponent<NetworkIdentity>();
+            if (identity != null)
+                return true;
+
+            identity = go.GetComponentInParent<NetworkIdentity>(true);
+            if (identity != null)
+                return true;
+
+            Debug.LogError($"GameObject {go.name} doesn't have NetworkIdentity.");
+            return false;
         }
 
         // disconnect //////////////////////////////////////////////////////////


### PR DESCRIPTION
fix for issue reported in: Error "Mirror.NetworkTransform on Turret requires a NetworkIdentity. Please add a NetworkIdentity component to Turret or it's parents." in clean project #3550

somehow UNITY_2021_OR_NEWER is evaluated to false where it should be true. This fixes error message in UnityEditor
EditorTests are fine, some Runtime tests on my manchine are failing, but only same as before.