### PR TITLE
feature: NetworkTransform WorldScale option

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -50,9 +50,6 @@ namespace Mirror
         public bool syncRotation = true;  // do not change at runtime!
         public bool syncScale = false; // do not change at runtime! rare. off by default.
 
-        [Tooltip("Set to false to use world coordinates, world will be better when changing hierarchy of target transform.")]
-        public bool localCoordinates = true;
-
         // interpolation is on by default, but can be disabled to jump to
         // the destination immediately. some projects need this.
         [Header("Interpolation")]
@@ -93,6 +90,10 @@ namespace Mirror
         public bool showGizmos;
         public bool showOverlay;
         public Color overlayColor = new Color(0, 0, 0, 0.5f);
+
+        [Header("Coordinate Space")]
+        [Tooltip("Set to false to use world coordinates for position, rotation and scale. World may be better when changing hierarchy of transforms, can optionally be changed during gameplay.")]
+        public bool localCoordinates = true;
 
         // initialization //////////////////////////////////////////////////////
         // make sure to call this when inheriting too!

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -116,6 +116,10 @@ namespace Mirror
             // actually use NetworkServer.sendInterval.
             syncInterval = 0;
 
+            // Unity doesn't support setting world scale.
+            // OnValidate force disables syncScale in world mode.
+            if (coordinateSpace == CoordinateSpace.World) syncScale = false;
+
             // obsolete clientAuthority compatibility:
             // if it was used, then set the new SyncDirection automatically.
             // if it wasn't used, then don't touch syncDirection.
@@ -164,8 +168,10 @@ namespace Mirror
         {
             if (coordinateSpace == CoordinateSpace.Local)
                 target.localScale = scale;
-            else
-                target.lossyScale = scale; // TODO
+            // Unity doesn't support setting world scale.
+            // OnValidate disables syncScale in world mode.
+            // else
+                // target.lossyScale = scale; // TODO
         }
 
         // construct a snapshot of the current state

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -168,8 +168,6 @@ namespace Mirror
                 target.lossyScale = scale; // TODO
         }
 
-        // set local/world transform depending on coordinate space
-
         // construct a snapshot of the current state
         // => internal for testing
         protected virtual TransformSnapshot Construct()

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -91,10 +91,16 @@ namespace Mirror
         public bool showOverlay;
         public Color overlayColor = new Color(0, 0, 0, 0.5f);
 
+        // CoordinateSpace ///////////////////////////////////////////////////////////
+        public enum CoordinateSpace
+        {
+            LocalSpace,
+            WorldSpace
+        }
         [Header("Coordinate Space")]
-        [Tooltip("Set to false to use world coordinates for position, rotation and scale. World may be better when changing hierarchy of transforms, can optionally be changed during gameplay.")]
-        public bool localCoordinates = true;
-
+        [Tooltip("Local by default. World may be better when changing hierarchy, or non-NetworkTransforms root position/rotation/scale values.")]
+        public CoordinateSpace coordinateSpace;
+        
         // initialization //////////////////////////////////////////////////////
         // make sure to call this when inheriting too!
         protected virtual void Awake() { }
@@ -130,7 +136,7 @@ namespace Mirror
         // => internal for testing
         protected virtual TransformSnapshot Construct()
         {
-            if (localCoordinates)
+            if (coordinateSpace == CoordinateSpace.LocalSpace)
             {
                 // NetworkTime.localTime for double precision until Unity has it too
                 return new TransformSnapshot(
@@ -167,7 +173,7 @@ namespace Mirror
             //   client sends snapshot at t=10
             // then the server would assume that it's one super slow move and
             // replay it for 10 seconds.
-            if (localCoordinates)
+            if (coordinateSpace == CoordinateSpace.LocalSpace)
             {
                 if (!position.HasValue) position = snapshots.Count > 0 ? snapshots.Values[snapshots.Count - 1].position : target.localPosition;
                 if (!rotation.HasValue) rotation = snapshots.Count > 0 ? snapshots.Values[snapshots.Count - 1].rotation : target.localRotation;
@@ -214,7 +220,7 @@ namespace Mirror
             // -> but simply don't apply it. if the user doesn't want to sync
             //    scale, then we should not touch scale etc.
 
-            if (localCoordinates)
+            if (coordinateSpace == CoordinateSpace.LocalSpace)
             {
                 if (syncPosition)
                     target.localPosition = interpolatePosition ? interpolated.position : endGoal.position;

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -310,17 +310,35 @@ namespace Mirror
             if (serverSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (onlySyncOnChange &&
-                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+            if (localCoordinates)
             {
-                RewriteHistory(
-                    serverSnapshots,
-                    connectionToClient.remoteTimeStamp,
-                    NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
-                    NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
-                    target.localPosition,
-                    target.localRotation,
-                    target.localScale);
+                if (onlySyncOnChange &&
+                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                {
+                    RewriteHistory(
+                        serverSnapshots,
+                        connectionToClient.remoteTimeStamp,
+                        NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
+                        NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
+                        target.localPosition,
+                        target.localRotation,
+                        target.localScale);
+                }
+            }
+            else
+            {
+                if (onlySyncOnChange &&
+                    NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                {
+                    RewriteHistory(
+                        serverSnapshots,
+                        connectionToClient.remoteTimeStamp,
+                        NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
+                        NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
+                        target.position,
+                        target.rotation,
+                        target.root.localScale);
+                }
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -338,17 +356,35 @@ namespace Mirror
             if (IsClientWithAuthority) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (onlySyncOnChange &&
-                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+            if (localCoordinates)
             {
-                RewriteHistory(
-                    clientSnapshots,
-                    NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
-                    NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
-                    NetworkClient.sendInterval * sendIntervalMultiplier,
-                    target.localPosition,
-                    target.localRotation,
-                    target.localScale);
+                if (onlySyncOnChange &&
+                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                {
+                    RewriteHistory(
+                        clientSnapshots,
+                        NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
+                        NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
+                        NetworkClient.sendInterval * sendIntervalMultiplier,
+                        target.localPosition,
+                        target.localRotation,
+                        target.localScale);
+                }
+            }
+            else
+            {
+                if (onlySyncOnChange &&
+                    NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                {
+                    RewriteHistory(
+                        clientSnapshots,
+                        NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
+                        NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
+                        NetworkClient.sendInterval * sendIntervalMultiplier,
+                        target.position,
+                        target.rotation,
+                        target.root.localScale);
+                }
             }
 
             // add a small timeline offset to account for decoupled arrival of

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -310,7 +310,7 @@ namespace Mirror
             if (serverSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (localCoordinates)
+            if (coordinateSpace == CoordinateSpace.LocalSpace)
             {
                 if (onlySyncOnChange &&
                 NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
@@ -356,7 +356,7 @@ namespace Mirror
             if (IsClientWithAuthority) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (localCoordinates)
+            if (coordinateSpace == CoordinateSpace.LocalSpace)
             {
                 if (onlySyncOnChange &&
                 NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -311,16 +311,18 @@ namespace Mirror
 
             // 'only sync on change' needs a correction on every new move sequence.
             if (onlySyncOnChange &&
-            NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
+                GetTransform(out Vector3 currentPosition, out Quaternion currentRotation, out Vector3 currentScale);
+
                 RewriteHistory(
                     serverSnapshots,
                     connectionToClient.remoteTimeStamp,
                     NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
                     NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position,
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation,
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
+                    currentPosition,
+                    currentRotation,
+                    currentScale);
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -341,14 +343,16 @@ namespace Mirror
             if (onlySyncOnChange &&
                 NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
+                GetTransform(out Vector3 currentPosition, out Quaternion currentRotation, out Vector3 currentScale);
+
                 RewriteHistory(
                     clientSnapshots,
                     NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
                     NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
                     NetworkClient.sendInterval * sendIntervalMultiplier,
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position,
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation,
-                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
+                    currentPosition,
+                    currentRotation,
+                    currentScale);
             }
 
             // add a small timeline offset to account for decoupled arrival of

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -310,35 +310,17 @@ namespace Mirror
             if (serverSnapshots.Count >= connectionToClient.snapshotBufferSizeLimit) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (coordinateSpace == CoordinateSpace.LocalSpace)
+            if (onlySyncOnChange &&
+            NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
-                if (onlySyncOnChange &&
-                NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
-                {
-                    RewriteHistory(
-                        serverSnapshots,
-                        connectionToClient.remoteTimeStamp,
-                        NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
-                        NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
-                        target.localPosition,
-                        target.localRotation,
-                        target.localScale);
-                }
-            }
-            else
-            {
-                if (onlySyncOnChange &&
-                    NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
-                {
-                    RewriteHistory(
-                        serverSnapshots,
-                        connectionToClient.remoteTimeStamp,
-                        NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
-                        NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
-                        target.position,
-                        target.rotation,
-                        target.root.localScale);
-                }
+                RewriteHistory(
+                    serverSnapshots,
+                    connectionToClient.remoteTimeStamp,
+                    NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
+                    NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position,
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation,
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -356,35 +338,17 @@ namespace Mirror
             if (IsClientWithAuthority) return;
 
             // 'only sync on change' needs a correction on every new move sequence.
-            if (coordinateSpace == CoordinateSpace.LocalSpace)
+            if (onlySyncOnChange &&
+            NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
-                if (onlySyncOnChange &&
-                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
-                {
-                    RewriteHistory(
-                        clientSnapshots,
-                        NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
-                        NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
-                        NetworkClient.sendInterval * sendIntervalMultiplier,
-                        target.localPosition,
-                        target.localRotation,
-                        target.localScale);
-                }
-            }
-            else
-            {
-                if (onlySyncOnChange &&
-                    NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
-                {
-                    RewriteHistory(
-                        clientSnapshots,
-                        NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
-                        NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
-                        NetworkClient.sendInterval * sendIntervalMultiplier,
-                        target.position,
-                        target.rotation,
-                        target.root.localScale);
-                }
+                RewriteHistory(
+                    clientSnapshots,
+                    NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
+                    NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
+                    NetworkClient.sendInterval * sendIntervalMultiplier,
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position,
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation,
+                    coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
             }
 
             // add a small timeline offset to account for decoupled arrival of

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -339,7 +339,7 @@ namespace Mirror
 
             // 'only sync on change' needs a correction on every new move sequence.
             if (onlySyncOnChange &&
-            NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
+                NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
                 RewriteHistory(
                     clientSnapshots,

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -313,16 +313,14 @@ namespace Mirror
             if (onlySyncOnChange &&
                 NeedsCorrection(serverSnapshots, connectionToClient.remoteTimeStamp, NetworkServer.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
-                GetTransform(out Vector3 currentPosition, out Quaternion currentRotation, out Vector3 currentScale);
-
                 RewriteHistory(
                     serverSnapshots,
                     connectionToClient.remoteTimeStamp,
                     NetworkTime.localTime,                                  // arrival remote timestamp. NOT remote timeline.
                     NetworkServer.sendInterval * sendIntervalMultiplier,    // Unity 2019 doesn't have timeAsDouble yet
-                    currentPosition,
-                    currentRotation,
-                    currentScale);
+                    GetPosition(),
+                    GetRotation(),
+                    GetScale());
             }
 
             // add a small timeline offset to account for decoupled arrival of
@@ -343,16 +341,14 @@ namespace Mirror
             if (onlySyncOnChange &&
                 NeedsCorrection(clientSnapshots, NetworkClient.connection.remoteTimeStamp, NetworkClient.sendInterval * sendIntervalMultiplier, onlySyncOnChangeCorrectionMultiplier))
             {
-                GetTransform(out Vector3 currentPosition, out Quaternion currentRotation, out Vector3 currentScale);
-
                 RewriteHistory(
                     clientSnapshots,
                     NetworkClient.connection.remoteTimeStamp,               // arrival remote timestamp. NOT remote timeline.
                     NetworkTime.localTime,                                  // Unity 2019 doesn't have timeAsDouble yet
                     NetworkClient.sendInterval * sendIntervalMultiplier,
-                    currentPosition,
-                    currentRotation,
-                    currentScale);
+                    GetPosition(),
+                    GetRotation(),
+                    GetScale());
             }
 
             // add a small timeline offset to account for decoupled arrival of

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -276,10 +276,9 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                GetTransform(out Vector3 position, out Quaternion rotation, out Vector3 scale);
-                if (syncPosition) writer.WriteVector3(position);
-                if (syncRotation) writer.WriteQuaternion(rotation);
-                if (syncScale)    writer.WriteVector3(scale);
+                if (syncPosition) writer.WriteVector3(GetPosition());
+                if (syncRotation) writer.WriteQuaternion(GetRotation());
+                if (syncScale)    writer.WriteVector3(GetScale());
             }
         }
 
@@ -290,18 +289,9 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (coordinateSpace == CoordinateSpace.LocalSpace)
-                {
-                    if (syncPosition) target.localPosition = reader.ReadVector3();
-                    if (syncRotation) target.localRotation = reader.ReadQuaternion();
-                    if (syncScale) target.localScale = reader.ReadVector3();
-                }
-                else
-                {
-                    if (syncPosition) target.position = reader.ReadVector3();
-                    if (syncRotation) target.rotation = reader.ReadQuaternion();
-                    if (syncScale) target.root.localScale = reader.ReadVector3();
-                }
+                if (syncPosition) SetPosition(reader.ReadVector3());
+                if (syncRotation) SetRotation(reader.ReadQuaternion());
+                if (syncScale)       SetScale(reader.ReadVector3());
             }
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -276,18 +276,9 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (coordinateSpace == CoordinateSpace.LocalSpace)
-                {
-                    if (syncPosition) writer.WriteVector3(target.localPosition);
-                    if (syncRotation) writer.WriteQuaternion(target.localRotation);
-                    if (syncScale) writer.WriteVector3(target.localScale);
-                }
-                else
-                {
-                    if (syncPosition) writer.WriteVector3(target.position);
-                    if (syncRotation) writer.WriteQuaternion(target.rotation);
-                    if (syncScale) writer.WriteVector3(target.root.localScale);
-                }
+                if (syncPosition) writer.WriteVector3(coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position);
+                if (syncRotation) writer.WriteQuaternion(coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation);
+                if (syncScale) writer.WriteVector3(coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
             }
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -276,9 +276,18 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (syncPosition) writer.WriteVector3(target.localPosition);
-                if (syncRotation) writer.WriteQuaternion(target.localRotation);
-                if (syncScale) writer.WriteVector3(target.localScale);
+                if (localCoordinates)
+                {
+                    if (syncPosition) writer.WriteVector3(target.localPosition);
+                    if (syncRotation) writer.WriteQuaternion(target.localRotation);
+                    if (syncScale) writer.WriteVector3(target.localScale);
+                }
+                else
+                {
+                    if (syncPosition) writer.WriteVector3(target.position);
+                    if (syncRotation) writer.WriteQuaternion(target.rotation);
+                    if (syncScale) writer.WriteVector3(target.root.localScale);
+                }
             }
         }
 
@@ -289,9 +298,18 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (syncPosition) target.localPosition = reader.ReadVector3();
-                if (syncRotation) target.localRotation = reader.ReadQuaternion();
-                if (syncScale) target.localScale = reader.ReadVector3();
+                if (localCoordinates)
+                {
+                    if (syncPosition) target.localPosition = reader.ReadVector3();
+                    if (syncRotation) target.localRotation = reader.ReadQuaternion();
+                    if (syncScale) target.localScale = reader.ReadVector3();
+                }
+                else
+                {
+                    if (syncPosition) target.position = reader.ReadVector3();
+                    if (syncRotation) target.rotation = reader.ReadQuaternion();
+                    if (syncScale) target.root.localScale = reader.ReadVector3();
+                }
             }
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -276,7 +276,7 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (localCoordinates)
+                if (coordinateSpace == CoordinateSpace.LocalSpace)
                 {
                     if (syncPosition) writer.WriteVector3(target.localPosition);
                     if (syncRotation) writer.WriteQuaternion(target.localRotation);
@@ -298,7 +298,7 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (localCoordinates)
+                if (coordinateSpace == CoordinateSpace.LocalSpace)
                 {
                     if (syncPosition) target.localPosition = reader.ReadVector3();
                     if (syncRotation) target.localRotation = reader.ReadQuaternion();

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -276,9 +276,10 @@ namespace Mirror
             // (Spawn message wouldn't sync NTChild positions either)
             if (initialState)
             {
-                if (syncPosition) writer.WriteVector3(coordinateSpace == CoordinateSpace.LocalSpace ? target.localPosition : target.position);
-                if (syncRotation) writer.WriteQuaternion(coordinateSpace == CoordinateSpace.LocalSpace ? target.localRotation : target.rotation);
-                if (syncScale) writer.WriteVector3(coordinateSpace == CoordinateSpace.LocalSpace ? target.localScale : target.root.localScale);
+                GetTransform(out Vector3 position, out Quaternion rotation, out Vector3 scale);
+                if (syncPosition) writer.WriteVector3(position);
+                if (syncRotation) writer.WriteQuaternion(rotation);
+                if (syncScale)    writer.WriteVector3(scale);
             }
         }
 


### PR DESCRIPTION
Currently NT is local, and in some cases world is needed.
If people decided to change hierarchy, change child/parent, things can get out of sync, world fixes that.

- All tested, using tanks example, and dragging a player tank into empty gameobject, then this gameobjects position/rotation/scale and hierarchy changing live during gameplay. Switching to world bool fixes any problems caused by that.

Before
![before](https://github.com/MirrorNetworking/Mirror/assets/57072365/db251202-ae84-445d-84b4-e0245f7be4a8)

After
![after](https://github.com/MirrorNetworking/Mirror/assets/57072365/40eeb56b-477a-409c-9abf-e89b9bdcdd52)

![Screenshot 2023-07-30 at 21 21 09](https://github.com/MirrorNetworking/Mirror/assets/57072365/331f849c-fa21-4ca1-9398-1b999cb4bac4)

![Screenshot 2023-07-30 at 21 20 23](https://github.com/MirrorNetworking/Mirror/assets/57072365/3c893a88-ba98-4a3e-b93e-dd7a13ac8104)
