### PR TITLE
NT rename broke presets, fix.

### DIFF
--- a/Assets/Mirror/Presets/NetworkTransform/ClientAuth-Balanced.preset
+++ b/Assets/Mirror/Presets/NetworkTransform/ClientAuth-Balanced.preset
@@ -9,7 +9,7 @@ Preset:
   m_Name: ClientAuth-Balanced
   m_TargetType:
     m_NativeTypeID: 114
-    m_ManagedTypePPtr: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb,
+    m_ManagedTypePPtr: {fileID: 11500000, guid: a553cb17010b2403e8523b558bffbc14,
       type: 3}
     m_ManagedTypeFallback: 
   m_Properties:
@@ -67,6 +67,10 @@ Preset:
     objectReference: {fileID: 0}
   - target: {fileID: 0}
     propertyPath: interpolateScale
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: coordinateSpace
     value: 0
     objectReference: {fileID: 0}
   - target: {fileID: 0}

--- a/Assets/Mirror/Presets/NetworkTransform/ClientAuth-FastPaced.preset
+++ b/Assets/Mirror/Presets/NetworkTransform/ClientAuth-FastPaced.preset
@@ -9,7 +9,7 @@ Preset:
   m_Name: ClientAuth-FastPaced
   m_TargetType:
     m_NativeTypeID: 114
-    m_ManagedTypePPtr: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb,
+    m_ManagedTypePPtr: {fileID: 11500000, guid: a553cb17010b2403e8523b558bffbc14,
       type: 3}
     m_ManagedTypeFallback: 
   m_Properties:
@@ -67,6 +67,10 @@ Preset:
     objectReference: {fileID: 0}
   - target: {fileID: 0}
     propertyPath: interpolateScale
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: coordinateSpace
     value: 0
     objectReference: {fileID: 0}
   - target: {fileID: 0}

--- a/Assets/Mirror/Presets/NetworkTransform/ClientAuth-VeryCasual.preset
+++ b/Assets/Mirror/Presets/NetworkTransform/ClientAuth-VeryCasual.preset
@@ -9,7 +9,7 @@ Preset:
   m_Name: ClientAuth-VeryCasual
   m_TargetType:
     m_NativeTypeID: 114
-    m_ManagedTypePPtr: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb,
+    m_ManagedTypePPtr: {fileID: 11500000, guid: a553cb17010b2403e8523b558bffbc14,
       type: 3}
     m_ManagedTypeFallback: 
   m_Properties:
@@ -67,6 +67,10 @@ Preset:
     objectReference: {fileID: 0}
   - target: {fileID: 0}
     propertyPath: interpolateScale
+    value: 0
+    objectReference: {fileID: 0}
+  - target: {fileID: 0}
+    propertyPath: coordinateSpace
     value: 0
     objectReference: {fileID: 0}
   - target: {fileID: 0}


### PR DESCRIPTION
As title suggests, the rename of NetworkTransform to NetworkTransformUnreliable means the pre-set examples for users needed updating.
![Screenshot 2023-08-08 at 08 09 55](https://github.com/MirrorNetworking/Mirror/assets/57072365/0aa9c441-ef5f-4556-9e3a-eebca7726336)
