### PR TITLE
Update CouchPlayerManager.cs

### DIFF
--- a/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayerManager.cs
+++ b/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayerManager.cs
@@ -20,8 +20,9 @@ namespace Mirror.Examples.CouchCoop
         // can be non sync-list, but may be useful for future features
         readonly SyncList<GameObject> couchPlayersList = new SyncList<GameObject>();
 
-        private void Awake()
+        public override void OnStartAuthority()
         {
+            // hook up UI to local player, for cmd communication
             canvasScript = GameObject.FindObjectOfType<CanvasScript>();
             canvasScript.couchPlayerManager = this;
         }


### PR DESCRIPTION
Moved some code from Awake to OnStartAuthority to prevent a reference from getting overridden. Fixes Server/Host from not being able to add its own new local players, if remote players have maxed themselves out.