### PR TITLE
feat: option to stop disconnect after Exception

### DIFF
--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -31,6 +31,9 @@ namespace Mirror
         // size of message id header in bytes
         public const int IdSize = sizeof(ushort);
 
+        // Flag user can set to stop disconnections
+        public static bool DisconnectOnException = true;
+
         // Id <> Type lookup for debugging, profiler, etc.
         // important when debugging messageId errors!
         public static readonly Dictionary<ushort, Type> Lookup =
@@ -164,8 +167,10 @@ namespace Mirror
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"Disconnecting connId={conn.connectionId} to prevent exploits from an Exception in MessageHandler: {e.GetType().Name} {e.Message}\n{e.StackTrace}");
-                    conn.Disconnect();
+                    string disconnectMessage = DisconnectOnException ? " Disconnecting to prevent exploits" : "";
+                    Debug.LogError($"Exception in MessageHandler from connId={conn.connectionId}{disconnectMessage}: {e.GetType().Name} {e.Message}\n{e.StackTrace}");
+                    if (DisconnectOnException)
+                        conn.Disconnect();
                 }
             };
 


### PR DESCRIPTION
Most exceptions will be from developer mistakes not exploits so adding an option to not disconnect will allow games to be more stable.

For people using this, it would be best to have `DisconnectOnException` as `true` in editor or debug builds so that Exception are obvious and can be fixed. But in release mode it should be `false` so that players dont get disconnected unexpectedly