### PR TITLE
Reduce the amount of redundant 'Change' data serialized by SyncDictionary

### DIFF
--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -30,7 +30,7 @@ namespace Mirror
 
         abstract class ChangesTracker
         {
-            protected readonly List<Change> changes = new();
+            protected readonly List<Change> changes = new List<Change>();
             public uint Count => (uint)changes.Count;
             public List<Change> CurrentChanges => changes;
             public virtual void ClearChanges() => changes.Clear();
@@ -53,7 +53,7 @@ namespace Mirror
         // -> ResetTrackedFields is important for "changes head" as it means the next time any new slot gets changed, it results in at most 1 more change being added.
         class SingleChangePerKeyTracker : ChangesTracker
         {
-            readonly Dictionary<TKey, int> changeMap = new();
+            readonly Dictionary<TKey, int> changeMap = new Dictionary<TKey, int>();
             int changeCountDuringLastChangeMapReset = 0;
 
             public override void ClearChanges()

--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -1,7 +1,5 @@
 using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
-using UnityEngineInternal;
 
 namespace Mirror
 {


### PR DESCRIPTION
New logic is added here to track the changes that get made to a SyncDictionary which drastically reduces the amount of redundant data being sent over the network.

Now if several modifications get made to the same key, whether it is add/set/remove/clear, there will not be multiple "Change" entries recorded.

For example, if a dictionary has 10 different keys, and if each of the 10 keys have their values added/removed/set 1000 times each in a single frame, then there will still only be 10 "Change" elements.

A "Clear" operation will also clear all tracked "Changes". So in the above example where there are 10 changes, performing a `OP_CLEAR` operation would also destroy those 10 "Changes" and replace them with a single "Change" representing the `OP_CLEAR`.

The only exception to the above is this: `OnSerializeAll`, which will ensure that all existing changes will still be transmitted during the next `OnSerializeDelta` along with at-most 1 additional change for every distinct dictionary slot that gets modified at least once. This is the one situation where there might be a limited quantity of redundant "Changes" that get transmitted, but this is still limited.

Finally, while the default behavior of SyncDictionary is modified by these changes to prevent sending redundant change details, a boolean flag can be optionally passed to the SyncDictionary constructor. If set to `true`, the SyncDictionary will use the "old" method of tracking every single change regardless of whether or not the changes are redundant.


Please don't roast me too hard. I was just looking into some of Mirror's code and saw a TODO and thought I'd get some practice.