### PR TITLE
fix: Add OP_RENEW to SyncDictionary

### DIFF
--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -18,7 +18,8 @@ namespace Mirror
             OP_ADD,
             OP_CLEAR,
             OP_REMOVE,
-            OP_SET
+            OP_SET,
+            OP_RENEW
         }
 
         struct Change
@@ -128,6 +129,8 @@ namespace Mirror
                         break;
                     case Operation.OP_CLEAR:
                         break;
+                    case Operation.OP_RENEW:
+                        break;
                 }
             }
         }
@@ -151,6 +154,9 @@ namespace Mirror
             // the next time the list is synchronized
             // because they have already been applied
             changesAhead = (int)reader.ReadUInt();
+
+            //Call OP_RENEW when all items have been changed.
+            AddOperation(Operation.OP_RENEW, default, default, false);
         }
 
         public override void OnDeserializeDelta(NetworkReader reader)


### PR DESCRIPTION
When all SyncDictionary values are set simultaneously, this treats the serialization/deserialization as "all" instead of "delta" which means Callback will not be invoked, so you will miss data changes from the host.