### PR TITLE
fix: improve NetworkMessage ID Hashing to minimize collisions

### DIFF
--- a/Assets/Mirror/Core/NetworkMessages.cs
+++ b/Assets/Mirror/Core/NetworkMessages.cs
@@ -17,8 +17,18 @@ namespace Mirror
         // => addons can work with each other without knowing their ids before
         // => 2 bytes is enough to avoid collisions.
         //    registering a messageId twice will log a warning anyway.
-        public static readonly ushort Id =
-            (ushort)(typeof(T).FullName.GetStableHashCode());
+        public static readonly ushort Id = CalculateId();
+
+        // Gets the 32bit fnv1a hash
+        // To get it down to 16bit but still reduce hash collisions we cant just cast it to ushort
+        // Instead we take the highest 16bits of the 32bit hash and fold them with xor into the lower 16bits
+        // This will create a more uniform 16bit hash, the method is described in:
+        // http://www.isthe.com/chongo/tech/comp/fnv/ in section "Changing the FNV hash size - xor-folding"
+        private static ushort CalculateId()
+        {
+            int hash = typeof(T).FullName.GetStableHashCode();
+            return (ushort)((hash >> 16) ^ hash);
+        }
     }
 
     // message packing all in one place, instead of constructing headers in all

--- a/Assets/Mirror/Core/Tools/Extensions.cs
+++ b/Assets/Mirror/Core/Tools/Extensions.cs
@@ -12,18 +12,25 @@ namespace Mirror
 
         // string.GetHashCode is not guaranteed to be the same on all
         // machines, but we need one that is the same on all machines.
+        // Uses fnv1a as hash function for more uniform distribution http://www.isthe.com/chongo/tech/comp/fnv/
         // NOTE: Do not call this from hot path because it's slow O(N) for long method names.
         // - As of 2012-02-16 There are 2 design-time callers (weaver) and 1 runtime caller that caches.
         public static int GetStableHashCode(this string text)
         {
             unchecked
             {
-                int hash = 23;
-                foreach (char c in text)
-                    hash = hash * 31 + c;
+                uint hash = 0x811c9dc5;
+                uint prime = 0x1000193;
+
+                for (int i = 0; i < text.Length; ++i)
+                {
+                    byte value = (byte)text[i];
+                    hash = hash ^ value;
+                    hash *= prime;
+                }
 
                 //UnityEngine.Debug.Log($"Created stable hash {(ushort)hash} for {text}");
-                return hash;
+                return (int)hash;
             }
         }
 

--- a/Assets/Mirror/Core/Tools/Extensions.cs
+++ b/Assets/Mirror/Core/Tools/Extensions.cs
@@ -13,6 +13,7 @@ namespace Mirror
         // string.GetHashCode is not guaranteed to be the same on all
         // machines, but we need one that is the same on all machines.
         // Uses fnv1a as hash function for more uniform distribution http://www.isthe.com/chongo/tech/comp/fnv/
+        // Tests: https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
         // NOTE: Do not call this from hot path because it's slow O(N) for long method names.
         // - As of 2012-02-16 There are 2 design-time callers (weaver) and 1 runtime caller that caches.
         public static int GetStableHashCode(this string text)

--- a/Assets/Mirror/Tests/Editor/NetworkMessages/NetworkMessagesTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkMessages/NetworkMessagesTest.cs
@@ -45,7 +45,7 @@ namespace Mirror.Tests.NetworkMessagesTests
         {
             // "Mirror.Tests.MessageTests.TestMessage"
             Debug.Log(typeof(TestMessage).FullName);
-            Assert.That(NetworkMessageId<TestMessage>.Id, Is.EqualTo(22739));
+            Assert.That(NetworkMessageId<TestMessage>.Id, Is.EqualTo(28872));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Tools/ExtensionsTest.cs
+++ b/Assets/Mirror/Tests/Editor/Tools/ExtensionsTest.cs
@@ -12,7 +12,7 @@ namespace Mirror.Tests.Tools
         public void GetStableHashHode()
         {
             Assert.That("".GetStableHashCode(), Is.EqualTo(-2128831035));
-            Assert.That("Test".GetStableHashCode(), Is.EqualTo(23844169));
+            Assert.That("Test".GetStableHashCode(), Is.EqualTo(805092869));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Tools/ExtensionsTest.cs
+++ b/Assets/Mirror/Tests/Editor/Tools/ExtensionsTest.cs
@@ -11,7 +11,7 @@ namespace Mirror.Tests.Tools
         [Test]
         public void GetStableHashHode()
         {
-            Assert.That("".GetStableHashCode(), Is.EqualTo(23));
+            Assert.That("".GetStableHashCode(), Is.EqualTo(-2128831035));
             Assert.That("Test".GetStableHashCode(), Is.EqualTo(23844169));
         }
 


### PR DESCRIPTION
We got a hash collision for 2 network messages in our game even though we only have 68 network messages.

The old stable hash code function for strings did not create a good hash so I replaced it with the fnv1a algorithm to reduce hash collisions.

Mirror then casted the 32bit hash to a 16bit hash which made us lose 50% of the hash, so now I fold the 32 bit hash inside itself, 
which means we take the highest 16bit of the hash and xor them with the lowest 16bit of the hash to create a 16bit hash which is still uniform and avoids hash collisions.

We tested this change in Nimoyd besides also running the mirror tests.