### PR TITLE
Updated server build tooltip on NM

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -29,7 +29,7 @@ namespace Mirror
 
         /// <summary>Should the server auto-start when 'Server Build' is checked in build settings</summary>
         [Header("Headless Builds")]
-        [Tooltip("Should the server auto-start when 'Server Build' is checked in build settings")]
+        [Tooltip("Should the server auto-start when 'Dedicated Server' platform is selected, or 'Server Build' is checked in build settings.")]
         [FormerlySerializedAs("startOnHeadless")]
         public bool autoStartServerBuild = true;
 


### PR DESCRIPTION
Updating tooltip to include mentioning Unitys latest Dedicated Server platform option, should help some with some confusion that was seen in # help.    
old  
![tooltip](https://github.com/MirrorNetworking/Mirror/assets/57072365/93b11807-ce09-468c-8cd6-1968f868b7f8)
new  
![tooltip2](https://github.com/MirrorNetworking/Mirror/assets/57072365/2e8d522c-d25c-46d1-b038-69697b5af992)
