### PR TITLE
fix: NetworkTime creates it's own frame time in 2019

### DIFF
--- a/Assets/Mirror/Core/NetworkLoop.cs
+++ b/Assets/Mirror/Core/NetworkLoop.cs
@@ -187,6 +187,7 @@ namespace Mirror
             // however, we only want to call NetworkServer/Client in play mode.
             if (!Application.isPlaying) return;
 
+            NetworkTime.EarlyUpdate();
             //Debug.Log($"NetworkEarlyUpdate {Time.time}");
             NetworkServer.NetworkEarlyUpdate();
             NetworkClient.NetworkEarlyUpdate();

--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -50,11 +50,12 @@ namespace Mirror
         }
 #else
         // need stopwatch for older Unity versions, but it's quite slow.
-        // CAREFUL: unlike Time.time, this is not a FRAME time.
-        //          it changes during the frame too.
+        // CAREFUL: unlike Time.time, the stopwatch time is not a FRAME time.
+        //          it changes during the frame, so we have an extra step to "cache" it in EarlyUpdate.
         static readonly Stopwatch stopwatch = new Stopwatch();
         static NetworkTime() => stopwatch.Start();
-        public static double localTime => stopwatch.Elapsed.TotalSeconds;
+        static double localFrameTime;
+        public static double localTime => localFrameTime;
 #endif
 
         /// <summary>The time in seconds since the server started.</summary>
@@ -230,6 +231,13 @@ namespace Mirror
             // how long did this message take to come back
             double newRtt = localTime - message.localTime;
             conn._rtt.Add(newRtt);
+        }
+
+        internal static void EarlyUpdate()
+        {
+#if !UNITY_2020_3_OR_NEWER
+            localFrameTime = stopwatch.Elapsed.TotalSeconds;
+#endif
         }
     }
 }


### PR DESCRIPTION
Since we don't have double time there yet and the stopwatch will change during the frame which (can?) cause jitter and other artifacts 

supersedes #3623
See also #2838