### PR TITLE
fix: KCP V1.38 [2023-10-29] cookie fix & refactor

### DIFF
--- a/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpClient.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpClient.cs
@@ -15,7 +15,7 @@ namespace Edgegap
         // authentication
         public uint userId;
         public uint sessionId;
-        public ConnectionState state = ConnectionState.Disconnected;
+        public ConnectionState connectionState = ConnectionState.Disconnected;
 
         // ping
         double lastPingTime;
@@ -35,7 +35,7 @@ namespace Edgegap
         public void Connect(string relayAddress, ushort relayPort, uint userId, uint sessionId)
         {
             // reset last state
-            state = ConnectionState.Checking;
+            connectionState = ConnectionState.Checking;
             this.userId = userId;
             this.sessionId = sessionId;
 
@@ -70,11 +70,11 @@ namespace Edgegap
                             {
                                 // parse state
                                 if (reader.Remaining < 1) return false;
-                                ConnectionState last = state;
-                                state = (ConnectionState)reader.ReadByte();
+                                ConnectionState last = connectionState;
+                                connectionState = (ConnectionState)reader.ReadByte();
 
                                 // log state changes for debugging.
-                                if (state != last) Debug.Log($"EdgegapClient: state updated to: {state}");
+                                if (connectionState != last) Debug.Log($"EdgegapClient: state updated to: {connectionState}");
 
                                 // return true indicates Mirror to keep checking
                                 // for further messages.
@@ -94,7 +94,7 @@ namespace Edgegap
             catch (SocketException e)
             {
                 Log.Info($"EdgegapClient: looks like the other end has closed the connection. This is fine: {e}");
-                peer.Disconnect();
+                Disconnect();
             }
 
             return false;

--- a/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
@@ -87,7 +87,7 @@ namespace Edgegap
             EdgegapKcpClient client = (EdgegapKcpClient)this.client;
             client.userId = userId;
             client.sessionId = sessionId;
-            client.state = ConnectionState.Checking; // reset from last time
+            client.connectionState = ConnectionState.Checking; // reset from last time
             client.Connect(relayAddress, relayGameClientPort);
         }
         public override void ClientConnect(Uri uri)
@@ -137,7 +137,7 @@ namespace Edgegap
                 EdgegapKcpClient client = (EdgegapKcpClient)this.client;
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("State:");
-                GUILayout.Label(client.state.ToString());
+                GUILayout.Label(client.connectionState.ToString());
                 GUILayout.EndHorizontal();
             }
 

--- a/Assets/Mirror/Transports/KCP/KcpTransport.cs
+++ b/Assets/Mirror/Transports/KCP/KcpTransport.cs
@@ -256,20 +256,20 @@ namespace kcp2k
         // see also: https://github.com/vis2k/Mirror/pull/2777
         public long GetAverageMaxSendRate() =>
             server.connections.Count > 0
-                ? server.connections.Values.Sum(conn => conn.peer.MaxSendRate) / server.connections.Count
+                ? server.connections.Values.Sum(conn => conn.MaxSendRate) / server.connections.Count
                 : 0;
         public long GetAverageMaxReceiveRate() =>
             server.connections.Count > 0
-                ? server.connections.Values.Sum(conn => conn.peer.MaxReceiveRate) / server.connections.Count
+                ? server.connections.Values.Sum(conn => conn.MaxReceiveRate) / server.connections.Count
                 : 0;
         long GetTotalSendQueue() =>
-            server.connections.Values.Sum(conn => conn.peer.SendQueueCount);
+            server.connections.Values.Sum(conn => conn.SendQueueCount);
         long GetTotalReceiveQueue() =>
-            server.connections.Values.Sum(conn => conn.peer.ReceiveQueueCount);
+            server.connections.Values.Sum(conn => conn.ReceiveQueueCount);
         long GetTotalSendBuffer() =>
-            server.connections.Values.Sum(conn => conn.peer.SendBufferCount);
+            server.connections.Values.Sum(conn => conn.SendBufferCount);
         long GetTotalReceiveBuffer() =>
-            server.connections.Values.Sum(conn => conn.peer.ReceiveBufferCount);
+            server.connections.Values.Sum(conn => conn.ReceiveBufferCount);
 
         // PrettyBytes function from DOTSNET
         // pretty prints bytes as KB/MB/GB/etc.
@@ -312,12 +312,12 @@ namespace kcp2k
             {
                 GUILayout.BeginVertical("Box");
                 GUILayout.Label("CLIENT");
-                GUILayout.Label($"  MaxSendRate: {PrettyBytes(client.peer.MaxSendRate)}/s");
-                GUILayout.Label($"  MaxRecvRate: {PrettyBytes(client.peer.MaxReceiveRate)}/s");
-                GUILayout.Label($"  SendQueue: {client.peer.SendQueueCount}");
-                GUILayout.Label($"  ReceiveQueue: {client.peer.ReceiveQueueCount}");
-                GUILayout.Label($"  SendBuffer: {client.peer.SendBufferCount}");
-                GUILayout.Label($"  ReceiveBuffer: {client.peer.ReceiveBufferCount}");
+                GUILayout.Label($"  MaxSendRate: {PrettyBytes(client.MaxSendRate)}/s");
+                GUILayout.Label($"  MaxRecvRate: {PrettyBytes(client.MaxReceiveRate)}/s");
+                GUILayout.Label($"  SendQueue: {client.SendQueueCount}");
+                GUILayout.Label($"  ReceiveQueue: {client.ReceiveQueueCount}");
+                GUILayout.Label($"  SendBuffer: {client.SendBufferCount}");
+                GUILayout.Label($"  ReceiveBuffer: {client.ReceiveBufferCount}");
                 GUILayout.EndVertical();
             }
 
@@ -350,12 +350,12 @@ namespace kcp2k
             if (ClientConnected())
             {
                 string log = "kcp CLIENT @ time: " + NetworkTime.localTime + "\n";
-                log += $"  MaxSendRate: {PrettyBytes(client.peer.MaxSendRate)}/s\n";
-                log += $"  MaxRecvRate: {PrettyBytes(client.peer.MaxReceiveRate)}/s\n";
-                log += $"  SendQueue: {client.peer.SendQueueCount}\n";
-                log += $"  ReceiveQueue: {client.peer.ReceiveQueueCount}\n";
-                log += $"  SendBuffer: {client.peer.SendBufferCount}\n";
-                log += $"  ReceiveBuffer: {client.peer.ReceiveBufferCount}\n\n";
+                log += $"  MaxSendRate: {PrettyBytes(client.MaxSendRate)}/s\n";
+                log += $"  MaxRecvRate: {PrettyBytes(client.MaxReceiveRate)}/s\n";
+                log += $"  SendQueue: {client.SendQueueCount}\n";
+                log += $"  ReceiveQueue: {client.ReceiveQueueCount}\n";
+                log += $"  SendBuffer: {client.SendBufferCount}\n";
+                log += $"  ReceiveBuffer: {client.ReceiveBufferCount}\n\n";
                 Debug.Log(log);
             }
         }

--- a/Assets/Mirror/Transports/KCP/kcp2k/VERSION.txt
+++ b/Assets/Mirror/Transports/KCP/kcp2k/VERSION.txt
@@ -1,3 +1,8 @@
+V1.38 [2023-10-29]
+- fix: #54 mismatching cookie race condition. cookie is now included in all messages.
+- feature: Exposed local end point on KcpClient/Server
+- refactor: KcpPeer refactored as abstract class to remove KcpServer initialization workarounds
+
 V1.37 [2023-07-31]
 - fix: #47 KcpServer.Stop now clears connections so they aren't carried over to the next session
 - fix: KcpPeer doesn't log 'received unreliable message while not authenticated' anymore.

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpHeader.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpHeader.cs
@@ -7,7 +7,7 @@ namespace kcp2k
     public enum KcpHeader : byte
     {
         // don't react on 0x00. might help to filter out random noise.
-        Handshake  = 1,
+        Hello      = 1,
         // ping goes over reliable & KcpHeader for now. could go over unreliable
         // too. there is no real difference except that this is easier because
         // we already have a KcpHeader for reliable messages.

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
@@ -1,22 +1,124 @@
 // server needs to store a separate KcpPeer for each connection.
 // as well as remoteEndPoint so we know where to send data to.
+using System;
 using System.Net;
 
 namespace kcp2k
 {
-    // struct to avoid memory indirection
-    public struct KcpServerConnection
+    public class KcpServerConnection : KcpPeer
     {
-        // peer can't be set from constructor at the moment.
-        // because peer callbacks need to know 'connection'.
-        // see KcpServer.CreateConnection.
-        public KcpPeer peer;
         public readonly EndPoint remoteEndPoint;
 
-        public KcpServerConnection(EndPoint remoteEndPoint)
+        // callbacks
+        // even for errors, to allow liraries to show popups etc.
+        // instead of logging directly.
+        // (string instead of Exception for ease of use and to avoid user panic)
+        //
+        // events are readonly, set in constructor.
+        // this ensures they are always initialized when used.
+        // fixes https://github.com/MirrorNetworking/Mirror/issues/3337 and more
+        protected readonly Action<KcpServerConnection> OnConnectedCallback;
+        protected readonly Action<ArraySegment<byte>, KcpChannel> OnDataCallback;
+        protected readonly Action OnDisconnectedCallback;
+        protected readonly Action<ErrorCode, string> OnErrorCallback;
+        protected readonly Action<ArraySegment<byte>> RawSendCallback;
+
+        public KcpServerConnection(
+            Action<KcpServerConnection> OnConnected,
+            Action<ArraySegment<byte>, KcpChannel> OnData,
+            Action OnDisconnected,
+            Action<ErrorCode, string> OnError,
+            Action<ArraySegment<byte>> OnRawSend,
+            KcpConfig config,
+            uint cookie,
+            EndPoint remoteEndPoint)
+                : base(config, cookie)
         {
-            peer = null;
+            OnConnectedCallback = OnConnected;
+            OnDataCallback = OnData;
+            OnDisconnectedCallback = OnDisconnected;
+            OnErrorCallback = OnError;
+            RawSendCallback = OnRawSend;
+
             this.remoteEndPoint = remoteEndPoint;
+        }
+
+        // callbacks ///////////////////////////////////////////////////////////
+        protected override void OnAuthenticated()
+        {
+            // once we receive the first client hello,
+            // immediately reply with hello so the client knows the security cookie.
+            SendHello();
+            OnConnectedCallback(this);
+        }
+
+        protected override void OnData(ArraySegment<byte> message, KcpChannel channel) =>
+            OnDataCallback(message, channel);
+
+        protected override void OnDisconnected() =>
+            OnDisconnectedCallback();
+
+        protected override void OnError(ErrorCode error, string message) =>
+            OnErrorCallback(error, message);
+
+        protected override void RawSend(ArraySegment<byte> data) =>
+            RawSendCallback(data);
+        ////////////////////////////////////////////////////////////////////////
+
+        // insert raw IO. usually from socket.Receive.
+        // offset is useful for relays, where we may parse a header and then
+        // feed the rest to kcp.
+        public void RawInput(ArraySegment<byte> segment)
+        {
+            // ensure valid size: at least 1 byte for channel + 4 bytes for cookie
+            if (segment.Count <= 5) return;
+
+            // parse channel
+            // byte channel = segment[0]; ArraySegment[i] isn't supported in some older Unity Mono versions
+            byte channel = segment.Array[segment.Offset + 0];
+
+            // all server->client messages include the server's security cookie.
+            // all client->server messages except for the initial 'hello' include it too.
+            // parse the cookie and make sure it matches (except for initial hello).
+            Utils.Decode32U(segment.Array, segment.Offset + 1, out uint messageCookie);
+
+            // compare cookie to protect against UDP spoofing.
+            // messages won't have a cookie until after handshake.
+            // so only compare if we are authenticated.
+            // simply drop the message if the cookie doesn't match.
+            if (state == KcpState.Authenticated)
+            {
+                if (messageCookie != cookie)
+                {
+                    Log.Warning($"KcpServerConnection: dropped message with invalid cookie: {messageCookie} expected: {cookie} state: {state}");
+                    return;
+                }
+            }
+
+            // parse message
+            ArraySegment<byte> message = new ArraySegment<byte>(segment.Array, segment.Offset + 1+4, segment.Count - 1-4);
+
+            switch (channel)
+            {
+                case (byte)KcpChannel.Reliable:
+                {
+                    OnRawInputReliable(message);
+                    break;
+                }
+                case (byte)KcpChannel.Unreliable:
+                {
+                    OnRawInputUnreliable(message);
+                    break;
+                }
+                default:
+                {
+                    // invalid channel indicates random internet noise.
+                    // servers may receive random UDP data.
+                    // just ignore it, but log for easier debugging.
+                    Log.Warning($"KcpServerConnection: invalid channel header: {channel}, likely internet noise");
+                    break;
+                }
+            }
         }
     }
 }

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpState.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpState.cs
@@ -1,0 +1,4 @@
+namespace kcp2k
+{
+    public enum KcpState { Connected, Authenticated, Disconnected }
+}

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpState.cs.meta
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81a02c141a88d45d4a2f5ef68c6da75f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- fix: mismatching cookie race condition. cookie is now included in all messages. https://github.com/MirrorNetworking/kcp2k/issues/54
- feature: Exposed local end point on KcpClient/Server
- refactor: KcpPeer refactored as abstract class to remove KcpServer initialization workarounds