### PR TITLE
Fix authority property in NetworkBehaviour while in host mode

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -85,9 +85,8 @@ namespace Mirror
         // also note that this is a per-NetworkBehaviour flag.
         // another component may not be client authoritative, etc.
         public bool authority =>
-            isClient
-                ? syncDirection == SyncDirection.ClientToServer && isOwned
-                : syncDirection == SyncDirection.ServerToClient;
+            isServer && syncDirection == SyncDirection.ServerToClient ||
+            isClient && syncDirection == SyncDirection.ClientToServer && isOwned;
 
         /// <summary>The unique network Id of this object (unique at runtime).</summary>
         public uint netId => netIdentity.netId;

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -84,6 +84,11 @@ namespace Mirror
         //
         // also note that this is a per-NetworkBehaviour flag.
         // another component may not be client authoritative, etc.
+        //
+        // checking isServer firstly in case we are in host mode
+        // otherwise checking isClient && isOwned
+        // otherwise no authority
+        // fixes: https://github.com/MirrorNetworking/Mirror/issues/3529
         public bool authority =>
             isServer && syncDirection == SyncDirection.ServerToClient ||
             isClient && syncDirection == SyncDirection.ClientToServer && isOwned;


### PR DESCRIPTION
Fixes #3528.
Fixes #3529.
Closes #3530.

This fix changes behaviour of `NetworkBehaviour.authority` property to return true while you are host and has authority over object.

If server and syncDirection is ServerToClient - return true, otherwise false.
If client and syncDirection is ClientToServer and object is owned - return true, otherwise false.

This condition is more readable than the old one and is still fast.

Still there an possible usage error while on the server you are trying to use `OnStartAuthority` or `OnStopAuthority` since you have an `authority`. To fix this we need to allow usage of `OnStartAuthority` and `OnStartAuthority` on server. Maybe it is related to #3495.