### PR TITLE
fix: Port log for when Server has started and is listening.

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -122,6 +122,17 @@ namespace Mirror
 
             active = true;
             RegisterMessageHandlers();
+
+            if (Transport.active is PortTransport portTransport)
+            {
+#if UNITY_SERVER
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine($"Server listening on port {portTransport.Port}");
+                Console.ResetColor();
+#else
+                Debug.Log($"Server listening on port {portTransport.Port}");
+#endif
+            }
         }
 
         // initialization / shutdown ///////////////////////////////////////////


### PR DESCRIPTION
Allows users to know if Server has actually started and which port, and not just initialised.
Credits to Gadget for code and suggesting to have it in NetworkServer.
(Originally was going in KCP-only)