### PR TITLE
fix(PredictedState): Remove public accessors

### DIFF
--- a/Assets/Mirror/Core/Prediction/Prediction.cs
+++ b/Assets/Mirror/Core/Prediction/Prediction.cs
@@ -8,7 +8,7 @@ namespace Mirror
     // have a common interface.
     public interface PredictedState
     {
-        public double timestamp { get; }
+        double timestamp { get; }
 
         // predicted states should have absolute and delta values, for example:
         //   Vector3 position;
@@ -16,7 +16,7 @@ namespace Mirror
         // when inserting a correction between this one and the one before,
         // we need to adjust the delta:
         //   positionDelta *= multiplier;
-        public void AdjustDeltas(float multiplier);
+        void AdjustDeltas(float multiplier);
     }
 
     public static class Prediction


### PR DESCRIPTION
- Unity 2019 doesn't support `public` accessors inside interfaces.
- Compiles fine in all Unity versions without them.