### PR TITLE
fix: #3576 Pings are now stamped with a scene hash so we can drop messages before a (potentially long) scene load. fixes a bug where RTT would be very high after a long scene load.

### DIFF
--- a/Assets/Mirror/Core/Messages.cs
+++ b/Assets/Mirror/Core/Messages.cs
@@ -109,8 +109,8 @@ namespace Mirror
         // this way we can disregard messages from before a scene change.
         // otherwise a 30s loading pause would cause super high RTT after:
         // https://github.com/MirrorNetworking/Mirror/issues/3576
-        // (4 byte hash instead of N byte string to minimize bandwidth)
-        public int sceneHash;
+        // (2 byte hash instead of N byte string to minimize bandwidth)
+        public ushort sceneHash;
 
         // local time is used to calculate round trip time,
         // and to calculate the predicted time offset.
@@ -119,7 +119,7 @@ namespace Mirror
         // predicted time is sent to compare the final error, for debugging only
         public double predictedTimeAdjusted;
 
-        public NetworkPingMessage(int sceneHash, double localTime, double predictedTimeAdjusted)
+        public NetworkPingMessage(ushort sceneHash, double localTime, double predictedTimeAdjusted)
         {
             this.sceneHash = sceneHash;
             this.localTime = localTime;
@@ -135,8 +135,8 @@ namespace Mirror
         // this way we can disregard messages from before a scene change.
         // otherwise a 30s loading pause would cause super high RTT after:
         // https://github.com/MirrorNetworking/Mirror/issues/3576
-        // (4 byte hash instead of N byte string to minimize bandwidth)
-        public int sceneHash;
+        // (2 byte hash instead of N byte string to minimize bandwidth)
+        public ushort sceneHash;
 
         // local time is used to calculate round trip time.
         public double localTime;
@@ -145,7 +145,7 @@ namespace Mirror
         public double predictionErrorUnadjusted;
         public double predictionErrorAdjusted; // for debug purposes
 
-        public NetworkPongMessage(int sceneHash, double localTime, double predictionErrorUnadjusted, double predictionErrorAdjusted)
+        public NetworkPongMessage(ushort sceneHash, double localTime, double predictionErrorUnadjusted, double predictionErrorAdjusted)
         {
             this.sceneHash = sceneHash;
             this.localTime = localTime;

--- a/Assets/Mirror/Core/Messages.cs
+++ b/Assets/Mirror/Core/Messages.cs
@@ -105,6 +105,13 @@ namespace Mirror
     // whoever wants to measure rtt, sends this to the other end.
     public struct NetworkPingMessage : NetworkMessage
     {
+        // ping messages are stamped with scene name (as hash).
+        // this way we can disregard messages from before a scene change.
+        // otherwise a 30s loading pause would cause super high RTT after:
+        // https://github.com/MirrorNetworking/Mirror/issues/3576
+        // (4 byte hash instead of N byte string to minimize bandwidth)
+        public int sceneHash;
+
         // local time is used to calculate round trip time,
         // and to calculate the predicted time offset.
         public double localTime;
@@ -112,8 +119,9 @@ namespace Mirror
         // predicted time is sent to compare the final error, for debugging only
         public double predictedTimeAdjusted;
 
-        public NetworkPingMessage(double localTime, double predictedTimeAdjusted)
+        public NetworkPingMessage(int sceneHash, double localTime, double predictedTimeAdjusted)
         {
+            this.sceneHash = sceneHash;
             this.localTime = localTime;
             this.predictedTimeAdjusted = predictedTimeAdjusted;
         }
@@ -123,6 +131,13 @@ namespace Mirror
     // we can use this to calculate rtt.
     public struct NetworkPongMessage : NetworkMessage
     {
+        // ping messages are stamped with scene name (as hash).
+        // this way we can disregard messages from before a scene change.
+        // otherwise a 30s loading pause would cause super high RTT after:
+        // https://github.com/MirrorNetworking/Mirror/issues/3576
+        // (4 byte hash instead of N byte string to minimize bandwidth)
+        public int sceneHash;
+
         // local time is used to calculate round trip time.
         public double localTime;
 
@@ -130,8 +145,9 @@ namespace Mirror
         public double predictionErrorUnadjusted;
         public double predictionErrorAdjusted; // for debug purposes
 
-        public NetworkPongMessage(double localTime, double predictionErrorUnadjusted, double predictionErrorAdjusted)
+        public NetworkPongMessage(int sceneHash, double localTime, double predictionErrorUnadjusted, double predictionErrorAdjusted)
         {
+            this.sceneHash = sceneHash;
             this.localTime = localTime;
             this.predictionErrorUnadjusted = predictionErrorUnadjusted;
             this.predictionErrorAdjusted = predictionErrorAdjusted;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -130,7 +130,7 @@ namespace Mirror
                 // messages' timestamp and only send a message number.
                 // This way client's can't just modify the timestamp.
                 // predictedTime parameter is 0 because the server doesn't predict.
-                int sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode();
+                ushort sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode16();
                 NetworkPingMessage pingMessage = new NetworkPingMessage(sceneHash, NetworkTime.localTime, 0);
                 Send(pingMessage, Channels.Unreliable);
                 lastPingTime = NetworkTime.localTime;

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Mirror
 {
@@ -129,7 +130,8 @@ namespace Mirror
                 // messages' timestamp and only send a message number.
                 // This way client's can't just modify the timestamp.
                 // predictedTime parameter is 0 because the server doesn't predict.
-                NetworkPingMessage pingMessage = new NetworkPingMessage(NetworkTime.localTime, 0);
+                int sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode();
+                NetworkPingMessage pingMessage = new NetworkPingMessage(sceneHash, NetworkTime.localTime, 0);
                 Send(pingMessage, Channels.Unreliable);
                 lastPingTime = NetworkTime.localTime;
             }

--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 #if !UNITY_2020_3_OR_NEWER
 using Stopwatch = System.Diagnostics.Stopwatch;
 #endif
@@ -144,8 +145,11 @@ namespace Mirror
             {
                 // send raw predicted time without the offset applied yet.
                 // we then apply the offset to it after.
+                // include scene name (as hash)
+                int sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode();
                 NetworkPingMessage pingMessage = new NetworkPingMessage
                 (
+                    sceneHash,
                     localTime,
                     predictedTime
                 );
@@ -175,6 +179,7 @@ namespace Mirror
             // Debug.Log($"OnServerPing conn:{conn}");
             NetworkPongMessage pongMessage = new NetworkPongMessage
             (
+                message.sceneHash,
                 message.localTime,
                 unadjustedError,
                 adjustedError
@@ -189,6 +194,13 @@ namespace Mirror
         {
             // prevent attackers from sending timestamps which are in the future
             if (message.localTime > localTime) return;
+
+            // ping messages are stamped with scene name (as hash).
+            // this way we can disregard messages from before a scene change.
+            // otherwise a 30s loading pause would cause super high RTT after:
+            // https://github.com/MirrorNetworking/Mirror/issues/3576
+            int sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode();
+            if (message.sceneHash != sceneHash) return;
 
             // how long did this message take to come back
             double newRtt = localTime - message.localTime;
@@ -210,6 +222,7 @@ namespace Mirror
             // Debug.Log($"OnClientPing conn:{conn}");
             NetworkPongMessage pongMessage = new NetworkPongMessage
             (
+                message.sceneHash,
                 message.localTime,
                 0, 0 // server doesn't predict
             );

--- a/Assets/Mirror/Core/NetworkTime.cs
+++ b/Assets/Mirror/Core/NetworkTime.cs
@@ -146,7 +146,7 @@ namespace Mirror
                 // send raw predicted time without the offset applied yet.
                 // we then apply the offset to it after.
                 // include scene name (as hash)
-                int sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode();
+                ushort sceneHash = SceneManager.GetActiveScene().name.GetStableHashCode16();
                 NetworkPingMessage pingMessage = new NetworkPingMessage
                 (
                     sceneHash,


### PR DESCRIPTION
fix for https://github.com/MirrorNetworking/Mirror/issues/3576
- resetting statics isn't enough, we still get ~50 ping messages from the previous scene
- those need to be ignored, hence the scene hash
- with this, ping doesn't drop a beat. super consistent even through scene changes.