### PR TITLE
breaking: fix: #3652 host [Command]s are now simulated over a message queue instead of invoking them directly (credits: Brian B.)

### DIFF
--- a/Assets/Mirror/Core/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Core/LocalConnectionToClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Mirror
 {
@@ -7,6 +8,9 @@ namespace Mirror
     public class LocalConnectionToClient : NetworkConnectionToClient
     {
         internal LocalConnectionToServer connectionToServer;
+
+        // packet queue
+        internal readonly Queue<NetworkWriterPooled> queue = new Queue<NetworkWriterPooled>();
 
         public LocalConnectionToClient() : base(LocalConnectionId) {}
 
@@ -30,6 +34,35 @@ namespace Mirror
 
         // don't ping host client in host mode
         protected override void UpdatePing() {}
+
+        internal override void Update()
+        {
+            base.Update();
+
+            // process internal messages so they are applied at the correct time
+            while (queue.Count > 0)
+            {
+                // call receive on queued writer's content, return to pool
+                NetworkWriterPooled writer = queue.Dequeue();
+                ArraySegment<byte> message = writer.ToArraySegment();
+
+                // OnTransportData assumes a proper batch with timestamp etc.
+                // let's make a proper batch and pass it to OnTransportData.
+                Batcher batcher = GetBatchForChannelId(Channels.Reliable);
+                batcher.AddMessage(message, NetworkTime.localTime);
+
+                using (NetworkWriterPooled batchWriter = NetworkWriterPool.Get())
+                {
+                    // make a batch with our local time (double precision)
+                    if (batcher.GetBatch(batchWriter))
+                    {
+                        NetworkServer.OnTransportData(connectionId, batchWriter.ToArraySegment(), Channels.Reliable);
+                    }
+                }
+
+                NetworkWriterPool.Return(writer);
+            }
+        }
 
         internal void DisconnectInternal()
         {

--- a/Assets/Mirror/Core/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Core/LocalConnectionToClient.cs
@@ -17,6 +17,7 @@ namespace Mirror
             // instead of invoking it directly, we enqueue and process next update.
             // this way we can simulate a similar call flow as with remote clients.
             // the closer we get to simulating host as remote, the better!
+            // both directions do this, so [Command] and [Rpc] behave the same way.
 
             //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
             NetworkWriterPooled writer = NetworkWriterPool.Get();

--- a/Assets/Mirror/Core/LocalConnectionToServer.cs
+++ b/Assets/Mirror/Core/LocalConnectionToServer.cs
@@ -28,22 +28,15 @@ namespace Mirror
                 return;
             }
 
-            // OnTransportData assumes batching.
-            // so let's make a batch with proper timestamp prefix.
-            Batcher batcher = GetBatchForChannelId(channelId);
-            batcher.AddMessage(segment, NetworkTime.localTime);
+            // instead of invoking it directly, we enqueue and process next update.
+            // this way we can simulate a similar call flow as with remote clients.
+            // the closer we get to simulating host as remote, the better!
+            // both directions do this, so [Command] and [Rpc] behave the same way.
 
-            // flush it to the server's OnTransportData immediately.
-            // local connection to server always invokes immediately.
-            using (NetworkWriterPooled writer = NetworkWriterPool.Get())
-            {
-                // make a batch with our local time (double precision)
-                if (batcher.GetBatch(writer))
-                {
-                    NetworkServer.OnTransportData(connectionId, writer.ToArraySegment(), channelId);
-                }
-                else Debug.LogError("Local connection failed to make batch. This should never happen.");
-            }
+            //Debug.Log($"Enqueue {BitConverter.ToString(segment.Array, segment.Offset, segment.Count)}");
+            NetworkWriterPooled writer = NetworkWriterPool.Get();
+            writer.WriteBytes(segment.Array, segment.Offset, segment.Count);
+            connectionToClient.queue.Enqueue(writer);
         }
 
         internal override void Update()


### PR DESCRIPTION
in host mode, [Rpc]s are queued up and invoke in next update - similar to remote client behaviour.
[Command]s however were invoked directly, unlike with remote clients.

=> the behaviour should be the same for [Rpc] and [Command]
=> either invoke both immediately, or queue both for next update
=> queuing will give more predictable behaviour compared to remote clients when testing(!)


testing with Tanks demo:
<img width="898" alt="2023-11-16 - 17-36-29@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/eb6083ef-ec12-47d9-9207-f10f9b24a302">


**before:**
<img width="681" alt="2023-11-16 - 17-36-02@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/98e9650b-cb66-481b-a43b-e10bde185eb0">

**after:**
<img width="761" alt="2023-11-16 - 17-37-03@2x" src="https://github.com/MirrorNetworking/Mirror/assets/16416509/50698fca-0d13-46fe-86ae-3ffccc062ec0">
