### PR TITLE
fix: TanksCoop example, reset host values.

### DIFF
--- a/Assets/Mirror/Examples/TanksCoop/Scripts/TankController.cs
+++ b/Assets/Mirror/Examples/TanksCoop/Scripts/TankController.cs
@@ -97,5 +97,13 @@ namespace Mirror.Examples.TanksCoop
             }
 
         }
+
+        public override void OnStopServer()
+        {
+            // To prevent a bug that can be caused on client host, when scenes do not reset during play,
+            // tank variables are set as "missing", which Unity does not count as null/empty.
+            objectOwner = null;
+            playerController = null;
+        }
     }
 }


### PR DESCRIPTION
Added OnStopServer  - nulls, to prevent a bug that can be caused on client host, when scenes do not reset during play, tank variables are set as "missing", which Unity does not count as null/empty.

Tested as best I can.
If the logic checks out, should be good to merge.