### PR TITLE
fix(NetworkManager): Remove check for editor in Start

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -224,7 +224,7 @@ namespace Mirror
             // don't auto start in editor where we have a UI, only in builds.
             // otherwise if we switch to 'Dedicated Server' target and press
             // Play, it would auto start the server every time.
-            if (Utils.IsHeadless() && !Application.isEditor)
+            if (Utils.IsHeadless())
             {
                 if (autoStartServerBuild)
                 {


### PR DESCRIPTION
IsHeadless returns false for null graphics device in editor so isEditor check is never reached, let alone evaluated.