### PR TITLE
fix(NetworkManager): Revert to using UNITY_SERVER in Start

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -252,21 +252,27 @@ namespace Mirror
             // We can't do this in Awake because Awake is for initialization
             // and some transports might not be ready until Start.
             //
-            // don't auto start in editor where we have a UI, only in builds.
-            // otherwise if we switch to 'Dedicated Server' target and press
-            // Play, it would auto start the server every time.
-            if (Utils.IsHeadless())
+            // Note 1: It is intentional that selecting Dedicated Server in the
+            //         editor and clicking Play starts a server or client, depending
+            //         on the headlessStartMode. This is useful for debugging, but
+            //         it's only available starting with Unity 2021.
+            //
+            //         Unity 2019 / 2020 don't have Dedicated Server target yet and there's
+            //         no way to detect if Server Build is checked in Build Settings, so 
+            //         these Unity versions will never auto-start a server in Play Mode.
+            //
+            // Note 2: sendRate is applied in StartServer
+#if UNITY_SERVER
+            switch (headlessStartMode)
             {
-                switch (headlessStartMode)
-                {
-                    case HeadlessStartOptions.AutoStartServer:
-                        StartServer();
-                        break;
-                    case HeadlessStartOptions.AutoStartClient:
-                        StartClient();
-                        break;
-                }
+                case HeadlessStartOptions.AutoStartServer:
+                    StartServer();
+                    break;
+                case HeadlessStartOptions.AutoStartClient:
+                    StartClient();
+                    break;
             }
+#endif
         }
 
         // make sure to call base.Update() when overwriting


### PR DESCRIPTION
Using UNITY_SERVER allows editor to behave as build by auto-starting server or client in editor Play mode if Dedicated Server is selected.
- This reverts a change made on 6-Nov-2023
