### PR TITLE
fix: Reverts Utils.IsHeadless, back to using compiler symbols in place

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryBase.cs
@@ -84,11 +84,10 @@ namespace Mirror.Discovery
             if (transport == null)
                 transport = Transport.active;
 
+#if UNITY_SERVER
             // Server mode? then start advertising
-            if (Utils.IsHeadless())
-            {
-                AdvertiseServer();
-            }
+            AdvertiseServer();
+#endif
         }
 
         public static long RandomLong()

--- a/Assets/Mirror/Components/NetworkRoomManager.cs
+++ b/Assets/Mirror/Components/NetworkRoomManager.cs
@@ -251,11 +251,10 @@ namespace Mirror
             OnRoomServerDisconnect(conn);
             base.OnServerDisconnect(conn);
 
-            if (Utils.IsHeadless())
-            {
-                if (numPlayers < 1)
-                    StopServer();
-            }
+#if UNITY_SERVER
+            if (numPlayers < 1)
+                StopServer();
+#endif
         }
 
         // Sequential index used in round-robin deployment of players into instances and score positioning

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -252,21 +252,27 @@ namespace Mirror
             // We can't do this in Awake because Awake is for initialization
             // and some transports might not be ready until Start.
             //
-            // don't auto start in editor where we have a UI, only in builds.
-            // otherwise if we switch to 'Dedicated Server' target and press
-            // Play, it would auto start the server every time.
-            if (Utils.IsHeadless())
+            // Note 1: It is intentional that selecting Dedicated Server in the
+            //         editor and clicking Play starts a server or client, depending
+            //         on the headlessStartMode. This is useful for debugging, but
+            //         it's only available starting with Unity 2021.
+            //
+            //         Unity 2019 / 2020 don't have Dedicated Server target and there's
+            //         no way to detect if Server Build is checked in Build Settings, so 
+            //         these Unity versions will never auto-start a server in Play Mode.
+            //
+            // Note 2: sendRate is applied in StartServer
+#if UNITY_SERVER
+            switch (headlessStartMode)
             {
-                switch (headlessStartMode)
-                {
-                    case HeadlessStartOptions.AutoStartServer:
-                        StartServer();
-                        break;
-                    case HeadlessStartOptions.AutoStartClient:
-                        StartClient();
-                        break;
-                }
+                case HeadlessStartOptions.AutoStartServer:
+                    StartServer();
+                    break;
+                case HeadlessStartOptions.AutoStartClient:
+                    StartClient();
+                    break;
             }
+#endif
         }
 
         // make sure to call base.Update() when overwriting
@@ -716,11 +722,10 @@ namespace Mirror
         // useful for headless benchmark clients.
         public virtual void ConfigureHeadlessFrameRate()
         {
-            if (Utils.IsHeadless())
-            {
-                Application.targetFrameRate = sendRate;
-                // Debug.Log($"Server Tick Rate set to {Application.targetFrameRate} Hz.");
-            }
+#if UNITY_SERVER
+            Application.targetFrameRate = sendRate;
+            // Debug.Log($"Server Tick Rate set to {Application.targetFrameRate} Hz.");
+#endif
         }
 
         bool InitializeSingleton()

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -120,16 +120,13 @@ namespace Mirror
 
                 if (Transport.active is PortTransport portTransport)
                 {
-                    if (Utils.IsHeadless())
-                    {
-#if !UNITY_EDITOR
-                        Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine($"Server listening on port {portTransport.Port}");
-                        Console.ResetColor();
+#if !DEBUG && (UNITY_SERVER || UNITY_WEBGL)
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine($"Server listening on port {portTransport.Port}");
+                    Console.ResetColor();
 #else
-                        Debug.Log($"Server listening on port {portTransport.Port}");
+                    Debug.Log($"Server listening on port {portTransport.Port}");
 #endif
-                    }
                 }
                 else
                     Debug.Log("Server started listening");

--- a/Assets/Mirror/Core/Tools/Utils.cs
+++ b/Assets/Mirror/Core/Tools/Utils.cs
@@ -33,15 +33,6 @@ namespace Mirror
 
     public static class Utils
     {
-        // detect headless / dedicated server mode
-        // in Unity 2019/2020, we need to check if there is no graphics device.
-        // in Unity 2021+, we could check for the #if UNITY_SERVER define.
-        // checking graphics device is safest.
-        // => it works on all Unity versions.
-        // => it keeps all the code active instead of ifdefing it out.
-        public static bool IsHeadless() =>
-            SystemInfo.graphicsDeviceType == GraphicsDeviceType.Null;
-
         public static uint GetTrueRandomUInt()
         {
             // use Crypto RNG to avoid having time based duplicates

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -76,14 +76,11 @@ namespace Mirror.Examples.NetworkRoom
         public override void OnRoomServerPlayersReady()
         {
             // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
-            if (Utils.IsHeadless())
-            {
-                base.OnRoomServerPlayersReady();
-            }
-            else
-            {
-                showStartButton = true;
-            }
+#if UNITY_SERVER
+            base.OnRoomServerPlayersReady();
+#else
+            showStartButton = true;
+#endif
         }
 
         public override void OnGUI()

--- a/Assets/Mirror/Transports/Multiplex/MultiplexTransport.cs
+++ b/Assets/Mirror/Transports/Multiplex/MultiplexTransport.cs
@@ -285,17 +285,16 @@ namespace Mirror
 
                 if (transport is PortTransport portTransport)
                 {
-                    if (Utils.IsHeadless())
-                    {
-                        Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine($"Server listening on port {portTransport.Port}");
-                        Console.ResetColor();
-                    }
-                    else
-                    {
-                        Debug.Log($"Server listening on port {portTransport.Port}");
-                    }
+#if !DEBUG && (UNITY_SERVER || UNITY_WEBGL)
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine($"Server listening on port {portTransport.Port}");
+                    Console.ResetColor();
+#else
+                    Debug.Log($"Server listening on port {portTransport.Port}");
+#endif
                 }
+                else
+                    Debug.Log("Server started listening");
             }
         }
 
@@ -304,7 +303,7 @@ namespace Mirror
             foreach (Transport transport in transports)
                 transport.ServerStop();
         }
-        #endregion
+#endregion
 
         public override int GetMaxPacketSize(int channelId = 0)
         {


### PR DESCRIPTION
2019/2020 with Server Build box checked - works correctly with UNITY_SERVER
2021+ with Dedicated Server platform selected - works correctly with UNITY_SERVER

2019+ client build with -batchmode -nographics -- does not set UNITY_SERVER and starts as hidden app with no console window at all.
- Clearly this should just never be used, since there's no console window
- Doing a null GFX check doesn't help the lack of a console window
- server builds are better optimized as server vs client builds anyway.