### PR TITLE
Draft: Nt optimise position bandwidth.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -349,7 +349,7 @@ namespace Mirror
         [Command(channel = Channels.Unreliable)]
         void CmdClientToServerSyncCompress(Vector3? position, uint? rotation, Vector3? scale)
         {
-            OnClientToServerSync(position, Compression.DecompressQuaternion((uint)rotation), scale);
+            OnClientToServerSync(position, rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation, scale);
             //For client authority, immediately pass on the client snapshot to all other
             //clients instead of waiting for server to send its snapshots.
             if (syncDirection == SyncDirection.ClientToServer)

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -128,10 +128,6 @@ namespace Mirror
 #if onlySyncOnChange_BANDWIDTH_SAVING
                 if (compressRotation)
                 {
-                    //if (snapshot.rotation == null)
-                    //{
-                    //    snapshot.rotation = target.rotation;
-                    //}
                         RpcServerToClientSyncCompress(
                             // only sync what the user wants to sync
                             syncPosition && positionChanged ? snapshot.position : default(Vector3?),

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -493,7 +493,7 @@ namespace Mirror
         }
         public bool ShortValidCheck(float _value)
         {
-            if (_value * 100 < short.MaxValue)
+            if (_value * 100 < short.MaxValue && _value * 100 > short.MinValue)
             {
                 return true;
             }

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -390,8 +390,7 @@ namespace Mirror
         // only unreliable. see comment above of this file.
         [ClientRpc(channel = Channels.Unreliable)]
         void RpcServerToClientSyncCompress(Vector3? position, uint? rotation, Vector3? scale) =>
-        // OnServerToClientSync(position, Compression.DecompressQuaternion((uint)rotation), scale);
-        OnServerToClientSync(position, rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation, scale);
+            OnServerToClientSync(position, rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation, scale);
 
         // server broadcasts sync message to all clients
         protected virtual void OnServerToClientSync(Vector3? position, Quaternion? rotation, Vector3? scale)

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -131,11 +131,14 @@ namespace Mirror
 #if onlySyncOnChange_BANDWIDTH_SAVING
                 if (compressPosition && compressRotation)
                 {
+                    //Debug.Log("snapshot.position.x:" + snapshot.position.x);
+                    //Debug.Log("(short?)snapshot.position.x:" + (short?)snapshot.position.x);
+                    //Debug.Log("ShortRoundAndMultiply(snapshot.position.x):" + ShortRoundAndMultiply(snapshot.position.x));
                     RpcServerToClientSyncCompressPosition(
                             // only sync what the user wants to sync
-                            syncPosition && positionChanged ? (short?)snapshot.position.x : default(short?),
-                        syncPosition && positionChanged ? (short?)snapshot.position.y : default(short?),
-                        syncPosition && positionChanged ? (short?)snapshot.position.z : default(short?),
+                            syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.x) : default(short?),
+                        syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.y) : default(short?),
+                        syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.z) : default(short?),
                             syncRotation && rotationChanged ? Compression.CompressQuaternion(snapshot.rotation) : default(uint?),
                             syncScale && scaleChanged ? snapshot.scale : default(Vector3?)
                         );
@@ -251,10 +254,12 @@ namespace Mirror
 #if onlySyncOnChange_BANDWIDTH_SAVING
                 if (compressPosition && compressRotation)
                 {
+                    //Debug.Log("snapshot.position.x:" + snapshot.position.x);
+                    //Debug.Log("(short?)snapshot.position.x:" + (short?)snapshot.position.x);
                     CmdClientToServerSyncCompressPosition(
-                        syncPosition && positionChanged ? (short?)snapshot.position.x : default(short?),
-                        syncPosition && positionChanged ? (short?)snapshot.position.y : default(short?),
-                        syncPosition && positionChanged ? (short?)snapshot.position.z : default(short?),
+                        syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.x) : default(short?),
+                        syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.y) : default(short?),
+                        syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.z) : default(short?),
                         syncRotation && rotationChanged ? Compression.CompressQuaternion(snapshot.rotation) : default(uint?),
                         syncScale && scaleChanged ? snapshot.scale : default(Vector3?)
                     );
@@ -387,9 +392,9 @@ namespace Mirror
         {
             //OnClientToServerSync(new Vector3((float)positionX, (float)positionY, (float)positionZ), rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation, scale);
             OnClientToServerSync(
-                new Vector3(positionX.HasValue ? (float)positionX : target.position.x,
-                    positionX.HasValue ? (float)positionY : target.position.y,
-                    positionX.HasValue ? (float)positionZ : target.position.z),
+                new Vector3(positionX.HasValue ? ShortRoundAndDivide(positionX) : target.position.x,
+                    positionX.HasValue ? ShortRoundAndDivide(positionY) : target.position.y,
+                    positionX.HasValue ? ShortRoundAndDivide(positionZ) : target.position.z),
                 rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation,
                 scale);
             //For client authority, immediately pass on the client snapshot to all other
@@ -474,6 +479,15 @@ namespace Mirror
             }
 #endif
             AddSnapshot(clientSnapshots, NetworkClient.connection.remoteTimeStamp + timeStampAdjustment + offset, position, rotation, scale);
+        }
+
+        public short ShortRoundAndMultiply(float _value)
+        {
+            return (short)(_value * 100);
+        }
+        public float ShortRoundAndDivide(short? _value)
+        {
+            return (float)(_value / 100.0f);
         }
     }
 }

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -126,9 +126,6 @@ namespace Mirror
 #endif
 
 #if onlySyncOnChange_BANDWIDTH_SAVING
-<<<<<<< Updated upstream
-                RpcServerToClientSync(
-=======
                 if (compressRotation)
                 {
                     //if (snapshot.rotation == null)
@@ -145,17 +142,12 @@ namespace Mirror
                 else
                 {
                     RpcServerToClientSync(
->>>>>>> Stashed changes
                     // only sync what the user wants to sync
                     syncPosition && positionChanged ? snapshot.position : default(Vector3?),
                     syncRotation && rotationChanged ? snapshot.rotation : default(Quaternion?),
                     syncScale && scaleChanged ? snapshot.scale : default(Vector3?)
-<<<<<<< Updated upstream
-                );
-=======
                     );
                 }
->>>>>>> Stashed changes
 #else
                 RpcServerToClientSync(
                     // only sync what the user wants to sync
@@ -247,14 +239,6 @@ namespace Mirror
 #endif
 
 #if onlySyncOnChange_BANDWIDTH_SAVING
-<<<<<<< Updated upstream
-                CmdClientToServerSync(
-                    // only sync what the user wants to sync
-                    syncPosition && positionChanged ? snapshot.position : default(Vector3?),
-                    syncRotation && rotationChanged ? snapshot.rotation : default(Quaternion?),
-                    syncScale && scaleChanged ? snapshot.scale : default(Vector3?)
-                );
-=======
                 if (compressRotation)
                 {
                     CmdClientToServerSyncCompress(
@@ -273,7 +257,6 @@ namespace Mirror
                    syncScale && scaleChanged ? snapshot.scale : default(Vector3?)
                     );
                 }
->>>>>>> Stashed changes
 #else
                 CmdClientToServerSync(
                     // only sync what the user wants to sync
@@ -365,8 +348,6 @@ namespace Mirror
                 RpcServerToClientSync(position, rotation, scale);
         }
 
-<<<<<<< Updated upstream
-=======
         // cmd /////////////////////////////////////////////////////////////////
         // only unreliable. see comment above of this file.
         [Command(channel = Channels.Unreliable)]
@@ -379,7 +360,6 @@ namespace Mirror
                 RpcServerToClientSyncCompress(position, rotation, scale);
         }
 
->>>>>>> Stashed changes
         // local authority client sends sync message to server for broadcasting
         protected virtual void OnClientToServerSync(Vector3? position, Quaternion? rotation, Vector3? scale)
         {
@@ -409,8 +389,6 @@ namespace Mirror
         [ClientRpc(channel = Channels.Unreliable)]
         void RpcServerToClientSync(Vector3? position, Quaternion? rotation, Vector3? scale) =>
             OnServerToClientSync(position, rotation, scale);
-<<<<<<< Updated upstream
-=======
 
         // rpc /////////////////////////////////////////////////////////////////
         // only unreliable. see comment above of this file.
@@ -418,7 +396,6 @@ namespace Mirror
         void RpcServerToClientSyncCompress(Vector3? position, uint? rotation, Vector3? scale) =>
         // OnServerToClientSync(position, Compression.DecompressQuaternion((uint)rotation), scale);
         OnServerToClientSync(position, rotation.HasValue ? Compression.DecompressQuaternion((uint)rotation) : target.rotation, scale);
->>>>>>> Stashed changes
 
         // server broadcasts sync message to all clients
         protected virtual void OnServerToClientSync(Vector3? position, Quaternion? rotation, Vector3? scale)

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -129,11 +129,11 @@ namespace Mirror
 #endif
 
 #if onlySyncOnChange_BANDWIDTH_SAVING
-                if (compressPosition && compressRotation)
+                if (compressPosition && compressRotation
+                    && ShortValidCheck(snapshot.position.x)
+                    && ShortValidCheck(snapshot.position.y)
+                    && ShortValidCheck(snapshot.position.z))
                 {
-                    //Debug.Log("snapshot.position.x:" + snapshot.position.x);
-                    //Debug.Log("(short?)snapshot.position.x:" + (short?)snapshot.position.x);
-                    //Debug.Log("ShortRoundAndMultiply(snapshot.position.x):" + ShortRoundAndMultiply(snapshot.position.x));
                     RpcServerToClientSyncCompressPosition(
                             // only sync what the user wants to sync
                             syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.x) : default(short?),
@@ -252,11 +252,13 @@ namespace Mirror
 #endif
 
 #if onlySyncOnChange_BANDWIDTH_SAVING
-                if (compressPosition && compressRotation)
+                if (compressPosition && compressRotation
+                    && ShortValidCheck(snapshot.position.x)
+                    && ShortValidCheck(snapshot.position.y)
+                    && ShortValidCheck(snapshot.position.z))
                 {
-                    //Debug.Log("snapshot.position.x:" + snapshot.position.x);
-                    //Debug.Log("(short?)snapshot.position.x:" + (short?)snapshot.position.x);
                     CmdClientToServerSyncCompressPosition(
+                        // only sync what the user wants to sync
                         syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.x) : default(short?),
                         syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.y) : default(short?),
                         syncPosition && positionChanged ? ShortRoundAndMultiply(snapshot.position.z) : default(short?),
@@ -488,6 +490,17 @@ namespace Mirror
         public float ShortRoundAndDivide(short? _value)
         {
             return (float)(_value / 100.0f);
+        }
+        public bool ShortValidCheck(float _value)
+        {
+            if (_value * 100 < short.MaxValue)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Checks to see if value can fit into a short (rounded to 2 decimal places), if so, send that, else fallback to vector3 floats.
Is optional via bool.
If on, uses half the amount of position data, automatically switches to non-compressed position if user goes out of short.max unity range.

This PR should come first.
https://github.com/MirrorNetworking/Mirror/pull/3677