### PR TITLE
fix(NetworkManager): No Auth Required for NotReadyMessage

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -786,6 +786,7 @@ namespace Mirror
             NetworkClient.OnConnectedEvent = OnClientConnectInternal;
             NetworkClient.OnDisconnectedEvent = OnClientDisconnectInternal;
             NetworkClient.OnErrorEvent = OnClientError;
+            // Don't require authentication because server may send NotReadyMessage from ServerChangeScene
             NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal, false);
             NetworkClient.RegisterHandler<SceneMessage>(OnClientSceneInternal, false);
 

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -786,7 +786,7 @@ namespace Mirror
             NetworkClient.OnConnectedEvent = OnClientConnectInternal;
             NetworkClient.OnDisconnectedEvent = OnClientDisconnectInternal;
             NetworkClient.OnErrorEvent = OnClientError;
-            NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
+            NetworkClient.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal, false);
             NetworkClient.RegisterHandler<SceneMessage>(OnClientSceneInternal, false);
 
             if (playerPrefab != null)


### PR DESCRIPTION
Server may change scenes while a connected client is in the middle of authentication. That sends NotReadyMessage to all connections. If client receives that while not yet authenticated, they'd get kicked when they shouldn't.

A not-yet-authenticated client isn't Ready, so receiving a NotReadyMessage does nothing.