### PR TITLE
Modified command message for better fixing this problem.

### DIFF
--- a/Assets/Mirror/Core/Messages.cs
+++ b/Assets/Mirror/Core/Messages.cs
@@ -37,6 +37,7 @@ namespace Mirror
         public uint netId;
         public byte componentIndex;
         public ushort functionHash;
+		public string methodName;
         // the parameters for the Cmd function
         // -> ArraySegment to avoid unnecessary allocations
         public ArraySegment<byte> payload;

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -379,6 +379,7 @@ namespace Mirror
                 componentIndex = ComponentIndex,
                 // type+func so Inventory.RpcUse != Equipment.RpcUse
                 functionHash = (ushort)functionHashCode,
+				 methodName = functionFullName,
                 // segment to avoid reader allocations
                 payload = writer.ToArraySegment()
             };

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -315,7 +315,7 @@ namespace Mirror
                 // Ignore commands that may have been in flight before client received NotReadyMessage message.
                 // Unreliable messages may be out of order, so don't spam warnings for those.
                 if (channelId == Channels.Reliable)
-                    Debug.LogWarning("Command received while client is not ready.\nThis may be ignored if client intentionally set NotReady.");
+                    Debug.LogWarning($"Command received while client is not ready.\nThis may be ignored if client intentionally set NotReady. Problematic method name{msg.methodName}");
                 return;
             }
 


### PR DESCRIPTION
Command received while client is not ready.\nThis may be ignored if client intentionally set NotReady.
