### PR TITLE
feat(NetworkClient): Add RegisterHandler with ChannelId

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -515,6 +515,27 @@ namespace Mirror
             handlers[msgType] = NetworkMessages.WrapHandler((Action<NetworkConnection, T>)HandlerWrapped, requireAuthentication, exceptionsDisconnect);
         }
 
+        /// <summary>Register a handler for a message type T. Most should require authentication.</summary>
+        // This version passes channelId to the handler.
+        public static void RegisterHandler<T>(Action<T, int> handler, bool requireAuthentication = true)
+            where T : struct, NetworkMessage
+        {
+            ushort msgType = NetworkMessageId<T>.Id;
+            if (handlers.ContainsKey(msgType))
+            {
+                Debug.LogWarning($"NetworkClient.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
+            }
+
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+
+            // we use the same WrapHandler function for server and client.
+            // so let's wrap it to ignore the NetworkConnection parameter.
+            // it's not needed on client. it's always NetworkClient.connection.
+            void HandlerWrapped(NetworkConnection _, T value, int channelId) => handler(value, channelId);
+            handlers[msgType] = NetworkMessages.WrapHandler((Action<NetworkConnection, T, int>)HandlerWrapped, requireAuthentication, exceptionsDisconnect);
+        }
+
         /// <summary>Replace a handler for a particular message type. Should require authentication by default.</summary>
         // RegisterHandler throws a warning (as it should) if a handler is assigned twice
         // Use of ReplaceHandler makes it clear the user intended to replace the handler


### PR DESCRIPTION
- Same as NetworkServer...allows NetworkMessage handlers to have a channelId param

This is NetworkServer's version:
```cs
public static void RegisterHandler<T>(Action<NetworkConnectionToClient, T, int> handler, bool requireAuthentication = true)
    where T : struct, NetworkMessage
{
    ushort msgType = NetworkMessageId<T>.Id;
    if (handlers.ContainsKey(msgType))
    {
        Debug.LogWarning($"NetworkServer.RegisterHandler replacing handler for {typeof(T).FullName}, id={msgType}. If replacement is intentional, use ReplaceHandler instead to avoid this warning.");
    }

    // register Id <> Type in lookup for debugging.
    NetworkMessages.Lookup[msgType] = typeof(T);

    handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication, exceptionsDisconnect);
}
```
Server version usage:
```cs
NetworkServer.RegisterHandler<SomeMessage>(OnSomeMessage);

public void OnSomeMessage(NetworkConnectionToClient conn, SomeMessage msg, int channelId)
{
     if (channelId == Channels.Reliable) { }
}
```

With this PR, you can now do the same on NetworkClient:
```cs
NetworkClient.RegisterHandler<SomeMessage>(OnSomeMessage);

public void OnSomeMessage(SomeMessage msg, int channelId)
{
     if (channelId == Channels.Reliable) { }
}
```
