### PR TITLE
Make clientStarted non serialized

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -94,6 +94,7 @@ namespace Mirror
         public bool isOwned { get; internal set; }
 
         // public so NetworkManager can reset it from StopClient.
+        [NonSerialized]
         public bool clientStarted;
 
         /// <summary>The set of network connections (players) that can see this object.</summary>


### PR DESCRIPTION
clientStarted was private and then made public so it can be reset from the NetworkManager according to the code comment, but this shows it in the inspector now which it should not, so set it to non serialized to avoid having it in the inspector.