### PR TITLE
fix(NetworkTransform): Separate ResetState

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -311,9 +311,9 @@ namespace Mirror
         }
 
         [ClientRpc]
-        void RpcReset()
+        void RpcResetState()
         {
-            Reset();
+            ResetState();
         }
 
         // common Teleport code for client->server and server->client
@@ -367,7 +367,7 @@ namespace Mirror
             // -> maybe add destination as first entry?
         }
 
-        public virtual void Reset()
+        public virtual void ResetState()
         {
             // disabled objects aren't updated anymore.
             // so let's clear the buffers.
@@ -375,9 +375,14 @@ namespace Mirror
             clientSnapshots.Clear();
         }
 
+        public virtual void Reset()
+        {
+            ResetState();
+        }
+
         protected virtual void OnEnable()
         {
-            Reset();
+            ResetState();
 
             if (NetworkServer.active)
                 NetworkIdentity.clientAuthorityCallback += OnClientAuthorityChanged;
@@ -385,7 +390,7 @@ namespace Mirror
 
         protected virtual void OnDisable()
         {
-            Reset();
+            ResetState();
 
             if (NetworkServer.active)
                 NetworkIdentity.clientAuthorityCallback -= OnClientAuthorityChanged;
@@ -403,8 +408,8 @@ namespace Mirror
 
             if (syncDirection == SyncDirection.ClientToServer)
             {
-                Reset();
-                RpcReset();
+                ResetState();
+                RpcResetState();
             }
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformReliable.cs
@@ -402,9 +402,9 @@ namespace Mirror
         // reset state for next session.
         // do not ever call this during a session (i.e. after teleport).
         // calling this will break delta compression.
-        public override void Reset()
+        public override void ResetState()
         {
-            base.Reset();
+            base.ResetState();
 
             // reset delta
             lastSerializedPosition = Vector3Long.zero;

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -346,7 +346,7 @@ namespace Mirror
                 double timeIntervalCheck = bufferResetMultiplier * sendIntervalMultiplier * NetworkClient.sendInterval;
 
                 if (serverSnapshots.Count > 0 && serverSnapshots.Values[serverSnapshots.Count - 1].remoteTime + timeIntervalCheck < timestamp)
-                    Reset();
+                    ResetState();
             }
 
             AddSnapshot(serverSnapshots, connectionToClient.remoteTimeStamp + timeStampAdjustment + offset, position, rotation, scale);
@@ -401,7 +401,7 @@ namespace Mirror
                 double timeIntervalCheck = bufferResetMultiplier * sendIntervalMultiplier * NetworkServer.sendInterval;
 
                 if (clientSnapshots.Count > 0 && clientSnapshots.Values[clientSnapshots.Count - 1].remoteTime + timeIntervalCheck < timestamp)
-                    Reset();
+                    ResetState();
             }
 
             AddSnapshot(clientSnapshots, NetworkClient.connection.remoteTimeStamp + timeStampAdjustment + offset, position, rotation, scale);


### PR DESCRIPTION
We should not have hijacked Unity's callback for runtime resets.