### PR TITLE
feat(NetworkTransform): Default Sync Direction = Client To Server

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -378,6 +378,7 @@ namespace Mirror
         public virtual void Reset()
         {
             ResetState();
+            // default to ClientToServer so this works immediately for users
             syncDirection = SyncDirection.ClientToServer;
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -378,6 +378,7 @@ namespace Mirror
         public virtual void Reset()
         {
             ResetState();
+            syncDirection = SyncDirection.ClientToServer;
         }
 
         protected virtual void OnEnable()

--- a/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
@@ -314,6 +314,9 @@ namespace Mirror.Tests.NetworkTransformTests
             component.netIdentity.isClient = true;
             component.netIdentity.isLocalPlayer = true;
 
+            // client authority has to be disabled
+            component.syncDirection = SyncDirection.ServerToClient;
+
             // call OnClientToServerSync with authority and nullable types
             // to make sure it uses the last valid position then.
             component.OnServerToClientSync(new Vector3?(), new Quaternion?(), new Vector3?());


### PR DESCRIPTION
- This is done in Reset so Network Behaviour isn't effected.
- This will not change NT components already in place on objects / prefabs unless user manually chooses Reset in the inspector.