### PR TITLE
fix(NetworkIdentity): Separate ResetState

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1650,7 +1650,7 @@ namespace Mirror
                             // unspawned objects should be reset for reuse later.
                             if (wasUnspawned)
                             {
-                                identity.Reset();
+                                identity.ResetState();
                             }
                             // without unspawn handler, we need to disable/destroy.
                             else
@@ -1659,7 +1659,7 @@ namespace Mirror
                                 // they always stay in the scene, we don't destroy them.
                                 if (identity.sceneId != 0)
                                 {
-                                    identity.Reset();
+                                    identity.ResetState();
                                     identity.gameObject.SetActive(false);
                                 }
                                 // spawned objects are destroyed
@@ -1695,7 +1695,7 @@ namespace Mirror
                 if (InvokeUnSpawnHandler(identity.assetId, identity.gameObject))
                 {
                     // reset object after user's handler
-                    identity.Reset();
+                    identity.ResetState();
                 }
                 // otherwise fall back to default Destroy
                 else if (identity.sceneId == 0)
@@ -1709,7 +1709,7 @@ namespace Mirror
                     identity.gameObject.SetActive(false);
                     spawnableObjects[identity.sceneId] = identity;
                     // reset for scene objects
-                    identity.Reset();
+                    identity.ResetState();
                 }
 
                 // remove from dictionary no matter how it is unspawned

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1286,7 +1286,7 @@ namespace Mirror
         // the identity during destroy as people might want to be able to read
         // the members inside OnDestroy(), and we have no way of invoking reset
         // after OnDestroy is called.
-        internal void Reset()
+        internal void ResetState()
         {
             hasSpawned = false;
             clientStarted = false;

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1657,7 +1657,7 @@ namespace Mirror
             // otherwise simply .Reset() and set inactive again
             else if (mode == DestroyMode.Reset)
             {
-                identity.Reset();
+                identity.ResetState();
             }
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
@@ -140,7 +140,7 @@ namespace Mirror.Tests.NetworkIdentities
             // let's reset and initialize again with the added ones.
             // this should show the 'too many components' error
             LogAssert.Expect(LogType.Error, new Regex(".*too many NetworkBehaviour.*"));
-            serverIdentity.Reset();
+            serverIdentity.ResetState();
             // clientIdentity.Reset();
             serverIdentity.Awake();
             // clientIdentity.Awake();

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
@@ -624,7 +624,7 @@ namespace Mirror.Tests.NetworkIdentities
         }
 
         [Test]
-        public void Reset()
+        public void ResetState()
         {
             CreateNetworked(out GameObject _, out NetworkIdentity identity);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
@@ -637,7 +637,7 @@ namespace Mirror.Tests.NetworkIdentities
             identity.observers[43] = new NetworkConnectionToClient(2);
 
             // mark for reset and reset
-            identity.Reset();
+            identity.ResetState();
             Assert.That(identity.isServer, Is.False);
             Assert.That(identity.isClient, Is.False);
             Assert.That(identity.isLocalPlayer, Is.False);


### PR DESCRIPTION
We should not have hijacked Unity's callback for runtime resets.