### PR TITLE
fix(InterestManagement): Separate ResetState

### DIFF
--- a/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/Distance/DistanceInterestManagement.cs
@@ -25,7 +25,7 @@ namespace Mirror
         }
 
         [ServerCallback]
-        public override void Reset()
+        public override void ResetState()
         {
             lastRebuildTime = 0D;
             CustomRanges.Clear();

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -72,7 +72,7 @@ namespace Mirror
         }
 
         [ServerCallback]
-        public override void Reset()
+        public override void ResetState()
         {
             lastRebuildTime = 0D;
         }

--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -23,7 +23,7 @@ namespace Mirror
         }
 
         [ServerCallback]
-        public virtual void Reset() {}
+        public virtual void ResetState() {}
 
         // Callback used by the visibility system to determine if an observer
         // (player) can see the NetworkIdentity. If this function returns true,

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -161,7 +161,7 @@ namespace Mirror
 
             // reset Interest Management so that rebuild intervals
             // start at 0 when starting again.
-            if (aoi != null) aoi.Reset();
+            if (aoi != null) aoi.ResetState();
 
             // reset NetworkTime
             NetworkTime.ResetStatics();
@@ -244,7 +244,7 @@ namespace Mirror
             OnDisconnectedEvent = null;
             OnErrorEvent = null;
 
-            if (aoi != null) aoi.Reset();
+            if (aoi != null) aoi.ResetState();
         }
 
         static void RemoveTransportHandlers()

--- a/Assets/ScriptTemplates/54-Mirror__Custom Interest Management-CustomInterestManagement.cs.txt
+++ b/Assets/ScriptTemplates/54-Mirror__Custom Interest Management-CustomInterestManagement.cs.txt
@@ -75,7 +75,7 @@ public class #SCRIPTNAME# : InterestManagement
     /// Called by NetworkServer in Initialize and Shutdown
     /// </summary>
     [ServerCallback]
-    public override void Reset() { }
+    public override void ResetState() { }
 
     [ServerCallback]
     void Update()


### PR DESCRIPTION
We should not have hijacked Unity's callback for runtime resets.