### PR TITLE
Fix: Add missing replace handler override to NetworkServer

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -930,6 +930,14 @@ namespace Mirror
             ushort msgType = NetworkMessageId<T>.Id;
             handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication, exceptionsDisconnect);
         }
+        
+        /// <summary>Replace a handler for message type T. Most should require authentication.</summary>
+        public static void ReplaceHandler<T>(Action<NetworkConnectionToClient, T, int> handler, bool requireAuthentication = true)
+            where T : struct, NetworkMessage
+        {
+            ushort msgType = NetworkMessageId<T>.Id;
+            handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication, exceptionsDisconnect);
+        }
 
         /// <summary>Unregister a handler for a message type T.</summary>
         public static void UnregisterHandler<T>()


### PR DESCRIPTION
There is a RegisterHandler function that takes an channelId, but we dont have any replace handler override for this, yet we log warnings if a user replaces a handler to use a not existing ReplaceHandler function.