### PR TITLE
perf: Lowered spawn amount from 50k, to 10k- Low risk, Low priority

### DIFF
--- a/Assets/Mirror/Examples/BenchmarkIdle/MirrorBenchmarkIdle.unity
+++ b/Assets/Mirror/Examples/BenchmarkIdle/MirrorBenchmarkIdle.unity
@@ -367,6 +367,7 @@ MonoBehaviour:
   connectionQualityInterval: 3
   timeInterpolationGui: 0
   spawnAmount: 50000
+  spawnAmount: 10000
   interleave: 2
   spawnPrefab: {fileID: 449802645721213856, guid: 0ea79775d59804682a8cdd46b3811344,
     type: 3}


### PR DESCRIPTION
50k causes a long delay, and looks like Unity has initially frozen, even on beefy machines. To prevent users from thinking this, and perhaps force closing, amount is lowered to something still crazy, but more reasonable. :)
- Nothing else has been touched