### PR TITLE
feat(SyncVar): Arrays are supported

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarAttributeProcessor.cs
@@ -471,13 +471,6 @@ namespace Mirror.Weaver
                         continue;
                     }
 
-                    if (fd.FieldType.IsArray)
-                    {
-                        Log.Error($"{fd.Name} has invalid type. Use SyncLists instead of arrays", fd);
-                        WeavingFailed = true;
-                        continue;
-                    }
-
                     if (SyncObjectInitializer.ImplementsSyncObject(fd.FieldType))
                     {
                         Log.Warning($"{fd.Name} has [SyncVar] attribute. SyncLists should not be marked with SyncVar", fd);

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests.cs
@@ -39,13 +39,6 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
-        public void SyncVarsCantBeArray()
-        {
-            HasError("thisShouldntWork has invalid type. Use SyncLists instead of arrays",
-                "System.Int32[] WeaverSyncVarTests.SyncVarsCantBeArray.SyncVarsCantBeArray::thisShouldntWork");
-        }
-
-        [Test]
         public void SyncVarsSyncList()
         {
             // NOTE if this test fails without a warning:

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests_IsSuccess/SyncVarsCanBeArray.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests_IsSuccess/SyncVarsCanBeArray.cs
@@ -2,9 +2,9 @@ using Mirror;
 
 namespace WeaverSyncVarTests.SyncVarsCantBeArray
 {
-    class SyncVarsCantBeArray : NetworkBehaviour
+    class SyncVarsCanBeArray : NetworkBehaviour
     {
         [SyncVar]
-        int[] thisShouldntWork = new int[100];
+        int[] thisShouldWork = new int[100];
     }
 }

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests_IsSuccess/SyncVarsCanBeArray.cs.meta
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverSyncVarAttributeTests_IsSuccess/SyncVarsCanBeArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d0708030f93e2f498530168e9c644c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Tested host and remote client with the following:

```cs
[SyncVar(hook = nameof(DataChanged))] public byte[] data;

void DataChanged(byte[] _, byte[] newData)
{
    Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, this, $"DataChanged: {newData[3]}");
}

public override void OnStartServer()
{
    data = new byte[] { 1, 2, 3, (byte)Random.Range(100, 200) };
    InvokeRepeating(nameof(UpdateData), 1, 1);
}

[ServerCallback]
void UpdateData()
{
    data = new byte[] { 1, 2, 3, (byte)Random.Range(100, 200) };
}
```

![image](https://github.com/MirrorNetworking/Mirror/assets/9826063/40d7eaf3-768c-40c3-813a-e896f6c4c8e4)

We have this in Reader / Writer extensions:

```cs
public static T[] ReadArray<T>(this NetworkReader reader)
{
    int length = reader.ReadInt();

    // 'null' is encoded as '-1'
    if (length < 0) return null;

    // prevent allocation attacks with a reasonable limit.
    //   server shouldn't allocate too much on client devices.
    //   client shouldn't allocate too much on server in ClientToServer [SyncVar]s.
    if (length > NetworkReader.AllocationLimit)
            {
                // throw EndOfStream for consistency with ReadBlittable when out of data
                throw new EndOfStreamException($"NetworkReader attempted to allocate an Array<{typeof(T)}> with {length} elements, which is larger than the allowed limit of {NetworkReader.AllocationLimit}.");
            }

    // we can't check if reader.Remaining < length,
    // because we don't know sizeof(T) since it's a managed type.
    // if (length > reader.Remaining) throw new EndOfStreamException($"Received array that is too large: {length}");

    T[] result = new T[length];
    for (int i = 0; i < length; i++)
            {
                result[i] = reader.Read<T>();
            }
    return result;
}
```
```cs
public static void WriteArray<T>(this NetworkWriter writer, T[] array)
{
    // 'null' is encoded as '-1'
    if (array is null)
    {
        writer.WriteInt(-1);
        return;
    }

    // check if within max size, otherwise Reader can't read it.
    if (array.Length > NetworkReader.AllocationLimit)
        throw new IndexOutOfRangeException($"NetworkWriter.WriteArray - Array<{typeof(T)}> too big: {array.Length} elements. Limit: {NetworkReader.AllocationLimit}");

    writer.WriteInt(array.Length);
    for (int i = 0; i < array.Length; i++)
        writer.Write(array[i]);
}
```