### PR TITLE
fix(NetworkServer): ReplaceHandler - Add Message To Lookup Dictionary

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -928,6 +928,10 @@ namespace Mirror
             where T : struct, NetworkMessage
         {
             ushort msgType = NetworkMessageId<T>.Id;
+            
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+            
             handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication, exceptionsDisconnect);
         }
         
@@ -936,6 +940,10 @@ namespace Mirror
             where T : struct, NetworkMessage
         {
             ushort msgType = NetworkMessageId<T>.Id;
+            
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+            
             handlers[msgType] = NetworkMessages.WrapHandler(handler, requireAuthentication, exceptionsDisconnect);
         }
 


### PR DESCRIPTION
ReplaceHandler can register handler without ever calling RegisterHandler, which is a valid use case as there is no function to call to check if a handler is registered, so in cases where classes can be destroyed and recreated ReplaceHandler can be used to avoid warnings.

This PR makes sure that if RegisterHandler was never called the NetworkMessage is still added to our debug lookup dictionary.