### PR TITLE
fix(NetworkClient): ReplaceHandler - Add Message To Lookup Dictionary

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -561,6 +561,10 @@ namespace Mirror
             // so let's wrap it to ignore the NetworkConnection parameter.
             // it's not needed on client. it's always NetworkClient.connection.
             ushort msgType = NetworkMessageId<T>.Id;
+            
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+            
             void HandlerWrapped(NetworkConnection _, T value) => handler(_, value);
             handlers[msgType] = NetworkMessages.WrapHandler((Action<NetworkConnection, T>)HandlerWrapped, requireAuthentication, exceptionsDisconnect);
         }
@@ -575,6 +579,10 @@ namespace Mirror
             // so let's wrap it to ignore the NetworkConnection parameter.
             // it's not needed on client. it's always NetworkClient.connection.
             ushort msgType = NetworkMessageId<T>.Id;
+            
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+            
             void HandlerWrapped(NetworkConnection _, T value) => handler(value);
             handlers[msgType] = NetworkMessages.WrapHandler((Action<NetworkConnection, T>)HandlerWrapped, requireAuthentication, exceptionsDisconnect);
         }
@@ -589,6 +597,10 @@ namespace Mirror
             // so let's wrap it to ignore the NetworkConnection parameter.
             // it's not needed on client. it's always NetworkClient.connection.
             ushort msgType = NetworkMessageId<T>.Id;
+            
+            // register Id <> Type in lookup for debugging.
+            NetworkMessages.Lookup[msgType] = typeof(T);
+            
             void HandlerWrapped(NetworkConnection _, T value, int channelId) => handler(value, channelId);
             handlers[msgType] = NetworkMessages.WrapHandler((Action<NetworkConnection, T, int>)HandlerWrapped, requireAuthentication, exceptionsDisconnect);
         }


### PR DESCRIPTION
ReplaceHandler can register handler without ever calling RegisterHandler, which is a valid use case as there is no function to call to check if a handler is registered, so in cases where classes can be destroyed and recreated ReplaceHandler can be used to avoid warnings.

This PR makes sure that if RegisterHandler was never called the NetworkMessage is still added to our debug lookup dictionary.