### PR TITLE
breaking: perf: change NB.syncVarDirtyBits to field

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -135,8 +135,9 @@ namespace Mirror
         //   -> still supports dynamically sized types
         //
         // 64 bit mask, tracking up to 64 SyncVars.
-        protected ulong syncVarDirtyBits { get; private set; }
-        // 64 bit mask, tracking up to 64 sync collections (internal for tests).
+        // protected since NB child classes read this field in the weaver generated SerializeSyncVars method
+        protected ulong syncVarDirtyBits;
+        // 64 bit mask, tracking up to 64 sync collections.
         // internal for tests, field for faster access (instead of property)
         // TODO 64 SyncLists are too much. consider smaller mask later.
         internal ulong syncObjectDirtyBits;

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -504,7 +504,7 @@ namespace Mirror.Weaver
             worker.Emit(OpCodes.Ldarg_1);
             // base
             worker.Emit(OpCodes.Ldarg_0);
-            worker.Emit(OpCodes.Call, weaverTypes.NetworkBehaviourDirtyBitsReference);
+            worker.Emit(OpCodes.Ldfld, weaverTypes.NetworkBehaviourDirtyBitsReference);
             MethodReference writeUint64Func = writers.GetWriteFunc(weaverTypes.Import<ulong>(), ref WeavingFailed);
             worker.Emit(OpCodes.Call, writeUint64Func);
 
@@ -524,7 +524,7 @@ namespace Mirror.Weaver
                 // Generates: if ((base.get_syncVarDirtyBits() & 1uL) != 0uL)
                 // base
                 worker.Emit(OpCodes.Ldarg_0);
-                worker.Emit(OpCodes.Call, weaverTypes.NetworkBehaviourDirtyBitsReference);
+                worker.Emit(OpCodes.Ldfld, weaverTypes.NetworkBehaviourDirtyBitsReference);
                 // 8 bytes = long
                 worker.Emit(OpCodes.Ldc_I8, 1L << dirtyBit);
                 worker.Emit(OpCodes.And);

--- a/Assets/Mirror/Editor/Weaver/Resolvers.cs
+++ b/Assets/Mirror/Editor/Weaver/Resolvers.cs
@@ -42,6 +42,38 @@ namespace Mirror.Weaver
             return null;
         }
 
+        public static FieldReference ResolveField(TypeReference tr, AssemblyDefinition assembly, Logger Log, string name, ref bool WeavingFailed)
+        {
+            if (tr == null)
+            {
+                Log.Error($"Cannot resolve Field {name} without a class");
+                WeavingFailed = true;
+                return null;
+            }
+            FieldReference field = ResolveField(tr, assembly, Log, m => m.Name == name, ref WeavingFailed);
+            if (field == null)
+            {
+                Log.Error($"Field not found with name {name} in type {tr.Name}", tr);
+                WeavingFailed = true;
+            }
+            return field;
+        }
+
+        public static FieldReference ResolveField(TypeReference t, AssemblyDefinition assembly, Logger Log, System.Func<FieldDefinition, bool> predicate, ref bool WeavingFailed)
+        {
+            foreach (FieldDefinition fieldRef in t.Resolve().Fields)
+            {
+                if (predicate(fieldRef))
+                {
+                    return assembly.MainModule.ImportReference(fieldRef);
+                }
+            }
+
+            Log.Error($"Field not found in type {t.Name}", t);
+            WeavingFailed = true;
+            return null;
+        }
+
         public static MethodReference TryResolveMethodInParents(TypeReference tr, AssemblyDefinition assembly, string name)
         {
             if (tr == null)

--- a/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
+++ b/Assets/Mirror/Editor/Weaver/WeaverTypes.cs
@@ -10,7 +10,7 @@ namespace Mirror.Weaver
     {
         public MethodReference ScriptableObjectCreateInstanceMethod;
 
-        public MethodReference NetworkBehaviourDirtyBitsReference;
+        public FieldReference NetworkBehaviourDirtyBitsReference;
         public MethodReference GetWriterReference;
         public MethodReference ReturnWriterReference;
 
@@ -90,7 +90,7 @@ namespace Mirror.Weaver
 
             TypeReference NetworkBehaviourType = Import<NetworkBehaviour>();
 
-            NetworkBehaviourDirtyBitsReference = Resolvers.ResolveProperty(NetworkBehaviourType, assembly, "syncVarDirtyBits");
+            NetworkBehaviourDirtyBitsReference = Resolvers.ResolveField(NetworkBehaviourType, assembly, Log, "syncVarDirtyBits", ref WeavingFailed);
 
             generatedSyncVarSetter = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter", ref WeavingFailed);
             generatedSyncVarSetter_GameObject = Resolvers.ResolveMethod(NetworkBehaviourType, assembly, Log, "GeneratedSyncVarSetter_GameObject", ref WeavingFailed);


### PR DESCRIPTION
@miwarnec saw the property showing up while profiling. 
Very much unnecessary, so lets change that to a field.

BREAKING: Changed NetworkBehaviour.syncVarDirtyBits from a "get-only" property to a field