### PR TITLE
feat(NetworkRigidbody): Default Sync Direction = Client To Server

### DIFF
--- a/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkLerpRigidbody.cs
@@ -38,8 +38,15 @@ namespace Mirror.Experimental
         protected override void OnValidate()
         {
             base.OnValidate();
+            Reset();
+        }
+
+        public virtual void Reset()
+        {
             if (target == null)
                 target = GetComponent<Rigidbody>();
+
+            syncDirection = SyncDirection.ClientToServer;
         }
 
         void Update()

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody.cs
@@ -42,8 +42,15 @@ namespace Mirror.Experimental
         protected override void OnValidate()
         {
             base.OnValidate();
+            Reset();
+        }
+
+        public virtual void Reset()
+        {
             if (target == null)
                 target = GetComponent<Rigidbody>();
+
+            syncDirection = SyncDirection.ClientToServer;
         }
 
         #region Sync vars

--- a/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkRigidbody2D.cs
@@ -40,8 +40,15 @@ namespace Mirror.Experimental
         protected override void OnValidate()
         {
             base.OnValidate();
+            Reset();
+        }
+
+        public virtual void Reset()
+        {
             if (target == null)
                 target = GetComponent<Rigidbody2D>();
+
+            syncDirection = SyncDirection.ClientToServer;
         }
 
         #region Sync vars


### PR DESCRIPTION
- This is done in Reset so Network Behaviour isn't effected.
- This will not change components already in place on objects / prefabs unless user manually chooses Reset in the inspector.