### PR TITLE
fix: Safer version for FindAnyObjectByType

### DIFF
--- a/Assets/Mirror/Examples/BilliardsPredicted/Player/PlayerPredicted.cs
+++ b/Assets/Mirror/Examples/BilliardsPredicted/Player/PlayerPredicted.cs
@@ -30,7 +30,7 @@ namespace Mirror.Examples.BilliardsPredicted
         void Awake()
         {
             // find the white ball once
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             whiteBall = FindAnyObjectByType<WhiteBallPredicted>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/CharacterSelection/Scripts/PlayerControllerScript.cs
+++ b/Assets/Mirror/Examples/CharacterSelection/Scripts/PlayerControllerScript.cs
@@ -83,7 +83,7 @@ namespace Mirror.Examples.CharacterSelection
             characterController.enabled = true;
             this.enabled = true;
 
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             sceneReferencer = GameObject.FindAnyObjectByType<SceneReferencer>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/CharacterSelection/Scripts/PlayerEmpty.cs
+++ b/Assets/Mirror/Examples/CharacterSelection/Scripts/PlayerEmpty.cs
@@ -10,7 +10,7 @@ namespace Mirror.Examples.CharacterSelection
         public override void OnStartAuthority()
         {
             // enable UI located in the scene, after empty player spawns in.
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             sceneReferencer = GameObject.FindAnyObjectByType<SceneReferencer>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayer.cs
+++ b/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayer.cs
@@ -26,7 +26,7 @@ namespace Mirror.Examples.CouchCoop
 
             if (isOwned)
             {
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
                 couchPlayerManager = GameObject.FindAnyObjectByType<CouchPlayerManager>();
 #else
                 // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayerManager.cs
+++ b/Assets/Mirror/Examples/CouchCoop/Scripts/CouchPlayerManager.cs
@@ -23,7 +23,7 @@ namespace Mirror.Examples.CouchCoop
         public override void OnStartAuthority()
         {
             // hook up UI to local player, for cmd communication
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             canvasScript = GameObject.FindAnyObjectByType<CanvasScript>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
@@ -33,7 +33,7 @@ namespace Mirror.Examples.MultipleMatch
 
         void Awake()
         {
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             canvasController = GameObject.FindAnyObjectByType<CanvasController>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchGUI.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchGUI.cs
@@ -19,7 +19,7 @@ namespace Mirror.Examples.MultipleMatch
 
         public void Awake()
         {
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             canvasController = GameObject.FindAnyObjectByType<CanvasController>();
 #else
             // Deprecated in Unity 2023.1

--- a/Assets/Mirror/Examples/_Common/Scripts/CanvasNetworkManagerHUD/CanvasNetworkManagerHUD.cs
+++ b/Assets/Mirror/Examples/_Common/Scripts/CanvasNetworkManagerHUD/CanvasNetworkManagerHUD.cs
@@ -188,7 +188,7 @@ namespace Mirror.Examples.Common
         // you first add this script to a gameobject.
         private void Reset()
         {
-#if UNITY_2021_3_OR_NEWER
+#if UNITY_2022_2_OR_NEWER
             if (!FindAnyObjectByType<NetworkManager>())
                 Debug.LogError("This component requires a NetworkManager component to be present in the scene. Please add!");
 #else


### PR DESCRIPTION
Unity docs are a mess on when FindAnyObjectByType was implemented:

- 2021.3 says it is
- 2022.1 says it's not
- 2022.2 says it is

We were not getting compile errors with 2021.3 latest build versions, but apparently some of the earlier builds it wasn't there yet, e.g.  2021.3.8 according to some Discord users, so bumping the compiler symbol up to 2022.2 is safer for compatibility.