### PR TITLE
feat: SWT overrides Transport.IsEncrypted & EncryptionCipher

### DIFF
--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -13,6 +13,9 @@ namespace Mirror.SimpleWeb
         public const string NormalScheme = "ws";
         public const string SecureScheme = "wss";
 
+        public override bool IsEncrypted => ClientConnected() && (clientUseWss || sslEnabled) || ServerActive() && sslEnabled;
+        public override string EncryptionCipher => "TLS"; // not technically correct, but there's no good way to get the actual cipher. Especially in browser
+
         [Tooltip("Protect against allocation attacks by keeping the max message size small. Otherwise an attacker might send multiple fake packets with 2GB headers, causing the server to run out of memory after allocating multiple large packets.")]
         public int maxMessageSize = 16 * 1024;
 


### PR DESCRIPTION
TLS isn't technically correct, but there's no good way to get that info