### PR TITLE
fix(LobbyServiceCreateDialogue): Added warning about Edgegap Lobby Name bug

### DIFF
--- a/Assets/Mirror/Transports/Edgegap/EdgegapLobby/LobbyServiceCreateDialogue.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapLobby/LobbyServiceCreateDialogue.cs
@@ -41,6 +41,7 @@ namespace Edgegap
                 Application.OpenURL("https://app.edgegap.com/user-settings?tab=tokens");
             }
             EditorGUILayout.Separator();
+            EditorGUILayout.HelpBox("There's currently a bug where lobby names longer than 5 characters can fail to deploy correctly and will return a \"503 Service Temporarily Unavailable\"\nIt's recommended to limit your lobby names to 4-5 characters for now", UnityEditor.MessageType.Warning);
             _name = EditorGUILayout.TextField("Lobby Name", _name);
             EditorGUILayout.HelpBox(new GUIContent("The lobby name is your games identifier for the lobby service"));
 


### PR DESCRIPTION
There's currently a bug where lobby names longer than 5 characters can fail to deploy correctly and will return a "503 Service Temporarily Unavailable"
So we'll just add a warning so users are aware to use a short name for now