### PR TITLE
fix(SyncDictionary): Clear after Callback

### DIFF
--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -195,12 +195,12 @@ namespace Mirror
                     case Operation.OP_CLEAR:
                         if (apply)
                         {
-                            objects.Clear();
                             // add dirty + changes.
                             // ClientToServer needs to set dirty in server OnDeserialize.
                             // no access check: server OnDeserialize can always
                             // write, even for ClientToServer (for broadcasting).
                             AddOperation(Operation.OP_CLEAR, default, default, false);
+                            objects.Clear();
                         }
                         break;
 
@@ -231,8 +231,9 @@ namespace Mirror
 
         public void Clear()
         {
-            objects.Clear();
+            // clear after invoking the callback so users can iterate the dictionary
             AddOperation(Operation.OP_CLEAR, default, default, true);
+            objects.Clear();
         }
 
         public bool ContainsKey(TKey key) => objects.ContainsKey(key);

--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -200,6 +200,8 @@ namespace Mirror
                             // no access check: server OnDeserialize can always
                             // write, even for ClientToServer (for broadcasting).
                             AddOperation(Operation.OP_CLEAR, default, default, false);
+                            // clear after invoking the callback so users can iterate the dictionary
+                            // and take appropriate action on the items before they are wiped.
                             objects.Clear();
                         }
                         break;
@@ -231,8 +233,9 @@ namespace Mirror
 
         public void Clear()
         {
-            // clear after invoking the callback so users can iterate the dictionary
             AddOperation(Operation.OP_CLEAR, default, default, true);
+            // clear after invoking the callback so users can iterate the dictionary
+            // and take appropriate action on the items before they are wiped.
             objects.Clear();
         }
 

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
@@ -97,7 +97,6 @@ namespace Mirror.Tests.SyncCollections
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_CLEAR));
                 Assert.That(clientSyncDictionary.Count, Is.EqualTo(3));
-
             };
             serverSyncDictionary.Clear();
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
@@ -89,9 +89,20 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void TestClear()
         {
+            // Verifies that the clear method works and that the data is still present for the Callback.
+            bool called = false;
+            clientSyncDictionary.Callback = (op, index, item) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_CLEAR));
+                Assert.That(clientSyncDictionary.Count, Is.EqualTo(3));
+
+            };
             serverSyncDictionary.Clear();
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(serverSyncDictionary, Is.EquivalentTo(new SyncDictionary<int, string>()));
+            Assert.That(called, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
This allows the data to be available in the callback for users to iterate and take actions as needed before it's wiped.