### PR TITLE
feat(SyncDictionary): Add individual Actions for operations

### DIFF
--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -6,6 +6,20 @@ namespace Mirror
 {
     public class SyncIDictionary<TKey, TValue> : SyncObject, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
     {
+        /// <summary>This is called after the item is added with TKey</summary>
+        public Action<TKey> OnAdd;
+
+        /// <summary>This is called after the item is changed with TKey. TValue is the OLD value</summary>
+        public Action<TKey, TValue> OnSet;
+
+        /// <summary>This is called after the item is removed with TKey. TValue is the OLD value</summary>
+        public Action<TKey, TValue> OnRemove;
+
+        /// <summary>This is called before the data is cleared</summary>
+        public Action OnClear;
+
+        // Deprecated 2024-03-22
+        [Obsolete("Use individual Actions, which pass OLD values where appropriate, instead.")]
         public Action<Operation, TKey, TValue> Callback;
 
         protected readonly IDictionary<TKey, TValue> objects;
@@ -83,7 +97,25 @@ namespace Mirror
                 OnDirty?.Invoke();
             }
 
+            switch (op)
+            {
+                case Operation.OP_ADD:
+                    OnAdd?.Invoke(key);
+                    break;
+                case Operation.OP_SET:
+                    OnSet?.Invoke(key, oldItem);
+                    break;
+                case Operation.OP_REMOVE:
+                    OnRemove?.Invoke(key, oldItem);
+                    break;
+                case Operation.OP_CLEAR:
+                    OnClear?.Invoke();
+                    break;
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Callback?.Invoke(op, key, item);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public override void OnSerializeAll(NetworkWriter writer)

--- a/Assets/Mirror/Core/SyncDictionary.cs
+++ b/Assets/Mirror/Core/SyncDictionary.cs
@@ -9,10 +9,10 @@ namespace Mirror
         /// <summary>This is called after the item is added with TKey</summary>
         public Action<TKey> OnAdd;
 
-        /// <summary>This is called after the item is changed with TKey. TValue is the OLD value</summary>
+        /// <summary>This is called after the item is changed with TKey. TValue is the OLD item</summary>
         public Action<TKey, TValue> OnSet;
 
-        /// <summary>This is called after the item is removed with TKey. TValue is the OLD value</summary>
+        /// <summary>This is called after the item is removed with TKey. TValue is the OLD item</summary>
         public Action<TKey, TValue> OnRemove;
 
         /// <summary>This is called before the data is cleared</summary>

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
@@ -58,7 +58,9 @@ namespace Mirror.Examples.MultipleMatch
 
         public override void OnStartClient()
         {
-            matchPlayerData.Callback += UpdateWins;
+#pragma warning disable CS0618 // Type or member is obsolete
+            matchPlayerData.Callback = UpdateWins;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             canvasGroup.alpha = 1f;
             canvasGroup.interactable = true;

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncDictionaryTest.cs
@@ -80,72 +80,131 @@ namespace Mirror.Tests.SyncCollections
         public void TestAdd()
         {
             // Adds a new entry with index of 4 using .Add method
+#pragma warning disable 618 // Type or member is obsolete
+            bool called = false;
+            clientSyncDictionary.Callback = (op, key, item) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_ADD));
+                Assert.That(key, Is.EqualTo(4));
+                Assert.That(item, Is.EqualTo("yay"));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
+            };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnAdd = (key) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(4));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
+            };
+
             serverSyncDictionary.Add(4, "yay");
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(clientSyncDictionary.ContainsKey(4));
             Assert.That(clientSyncDictionary[4], Is.EqualTo("yay"));
+            Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestClear()
         {
             // Verifies that the clear method works and that the data is still present for the Callback.
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-            clientSyncDictionary.Callback = (op, index, item) =>
+            clientSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_CLEAR));
                 Assert.That(clientSyncDictionary.Count, Is.EqualTo(3));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnClear = () =>
+            {
+                actionCalled = true;
+                Assert.That(clientSyncDictionary.Count, Is.EqualTo(3));
+            };
+
             serverSyncDictionary.Clear();
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(serverSyncDictionary, Is.EquivalentTo(new SyncDictionary<int, string>()));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestSet()
         {
             // Overwrites an existing entry
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-            clientSyncDictionary.Callback = (op, index, item) =>
+            clientSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_SET));
-                Assert.That(index, Is.EqualTo(1));
+                Assert.That(key, Is.EqualTo(1));
                 Assert.That(item, Is.EqualTo("yay"));
-                Assert.That(clientSyncDictionary[index], Is.EqualTo("yay"));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
 
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnSet = (key, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
+            };
+
             serverSyncDictionary[1] = "yay";
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(clientSyncDictionary.ContainsKey(1));
             Assert.That(clientSyncDictionary[1], Is.EqualTo("yay"));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestBareSet()
         {
             // Adds a new entry with index of 4 without using .Add method
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-            clientSyncDictionary.Callback = (op, index, item) =>
+            clientSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_ADD));
-                Assert.That(index, Is.EqualTo(4));
+                Assert.That(key, Is.EqualTo(4));
                 Assert.That(item, Is.EqualTo("yay"));
-                Assert.That(clientSyncDictionary[index], Is.EqualTo("yay"));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
 
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnAdd = (key) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(4));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
+            };
+
             serverSyncDictionary[4] = "yay";
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(clientSyncDictionary.ContainsKey(4));
             Assert.That(clientSyncDictionary[4], Is.EqualTo("yay"));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
@@ -209,52 +268,90 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void CallbackTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-            clientSyncDictionary.Callback = (op, index, item) =>
+            clientSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_ADD));
-                Assert.That(index, Is.EqualTo(3));
+                Assert.That(key, Is.EqualTo(3));
                 Assert.That(item, Is.EqualTo("yay"));
-                Assert.That(clientSyncDictionary[index], Is.EqualTo("yay"));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
 
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnAdd = (key) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(3));
+                Assert.That(clientSyncDictionary[key], Is.EqualTo("yay"));
+            };
+
             serverSyncDictionary.Add(3, "yay");
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void ServerCallbackTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-            serverSyncDictionary.Callback = (op, index, item) =>
+            serverSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
 
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_ADD));
-                Assert.That(index, Is.EqualTo(3));
+                Assert.That(key, Is.EqualTo(3));
                 Assert.That(item, Is.EqualTo("yay"));
-                Assert.That(serverSyncDictionary[index], Is.EqualTo("yay"));
+                Assert.That(serverSyncDictionary[key], Is.EqualTo("yay"));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            serverSyncDictionary.OnAdd = (key) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(3));
+                Assert.That(serverSyncDictionary[key], Is.EqualTo("yay"));
+            };
+
             serverSyncDictionary[3] = "yay";
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void CallbackRemoveTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncDictionary.Callback = (op, key, item) =>
             {
                 called = true;
                 Assert.That(op, Is.EqualTo(SyncDictionary<int, string>.Operation.OP_REMOVE));
+                Assert.That(key, Is.EqualTo(1));
                 Assert.That(item, Is.EqualTo("World"));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncDictionary.OnRemove = (key, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(key, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(!clientSyncDictionary.ContainsKey(1));
+            };
+
             serverSyncDictionary.Remove(1);
             SerializeDeltaTo(serverSyncDictionary, clientSyncDictionary);
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
- Set and Remove Actions pass **OLD** item
- Deprecates Callback Action

With the new Set and Remove Actions, users will be able to do work with the previous values, while accessing the new values by the dictionary key.

Below is an example that would be applicable for a card game or inventory:

```cs
using UnityEngine;
using Mirror;
using System;

public class SyncDictTest : NetworkBehaviour
{
    public struct ItemData
    {
        public byte prefabIndex;
        public Vector3 position;
        public Quaternion rotation;

        // this is not networked or serialized, it's only used on the client
        // to hold reference to the instantiated object for a dictionary item.
        [NonSerialized]
        public GameObject clientObject;

        public void CreateClientObject(GameObject prefab, Vector3 pos, Quaternion rot)
        {
            clientObject = Instantiate(prefab, pos, rot);
        }
    }

    public GameObject[] prefabs;

    public readonly SyncDictionary<ushort, ItemData> dict = new SyncDictionary<ushort, ItemData>();

    ushort nextIndex = 0;

    void Awake()
    {
        dict.OnAdd = OnAdd;
        dict.OnSet = OnSet;
        dict.OnRemove = OnRemove;
        dict.OnClear = OnClear;
    }

    public override void OnStartClient()
    {
        // Handlers not setup when spawned...call OnAdd for each.
        foreach (ushort key in dict.Keys)
            dict.OnAdd?.Invoke(key);
    }

    void OnAdd(ushort key)
    {
        dict[key].CreateClientObject(prefabs[dict[key].prefabIndex], dict[key].position, dict[key].rotation);
    }

    void OnSet(ushort key, ItemData oldItem)
    {
        if (dict[key].prefabIndex != oldItem.prefabIndex)
        {
            if (oldItem.clientObject != null)
                Destroy(oldItem.clientObject);

            dict[key].CreateClientObject(prefabs[dict[key].prefabIndex], dict[key].position, dict[key].rotation);
        }
        else
        {
            oldItem.clientObject.transform.position = dict[key].position;
            oldItem.clientObject.transform.rotation = dict[key].rotation;
        }
    }

    void OnRemove(ushort key, ItemData oldItem)
    {
        if (oldItem.clientObject != null)
            Destroy(oldItem.clientObject);
    }

    void OnClear()
    {
        foreach (ItemData itemData in dict.Values)
            if (itemData.clientObject != null)
                Destroy(itemData.clientObject);
    }

    [Command]
    public void CmdAddItem(byte prefabIndex, Vector3 position, Quaternion rotation)
    {
        dict[nextIndex] = new ItemData
        {
            prefabIndex = prefabIndex,
            position = position,
            rotation = rotation
        };

        nextIndex++;
    }

    [Command]
    public void CmdSetItem(ushort key, byte prefabIndex, Vector3 position, Quaternion rotation)
    {
        if (dict.TryGetValue(key, out ItemData item))
        {
            item.prefabIndex = prefabIndex;
            item.position = position;
            item.rotation = rotation;
            dict[key] = item;
        }
    }

    [Command]
    public void CmdReplaceItem(ushort key, byte prefabIndex)
    {
        if (dict.TryGetValue(key, out ItemData item))
        {
            item.prefabIndex = prefabIndex;
            dict[key] = item;
        }
    }

    [Command]
    public void CmdMoveItem(ushort key, Vector3 position)
    {
        if (dict.TryGetValue(key, out ItemData item))
        {
            item.position = position;
            dict[key] = item;
        }
    }

    [Command]
    public void CmdRotateItem(ushort key, Quaternion rotation)
    {
        if (dict.TryGetValue(key, out ItemData item))
        {
            item.rotation = rotation;
            dict[key] = item;
        }
    }

    [Command]
    public void CmdRemoveItem(ushort key)
    {
        dict.Remove(key);
    }

    [Command]
    public void CmdClearItems()
    {
        dict.Clear();
    }
}
```