### PR TITLE
feat(SyncList): Add individual Actions for operations

### DIFF
--- a/Assets/Mirror/Core/SyncList.cs
+++ b/Assets/Mirror/Core/SyncList.cs
@@ -15,6 +15,23 @@ namespace Mirror
             OP_CLEAR
         }
 
+        /// <summary>This is called after the item is added with index</summary>
+        public Action<int> OnAdd;
+
+        /// <summary>This is called after the item is inserted with inedx</summary>
+        public Action<int> OnInsert;
+
+        /// <summary>This is called after the item is set with index and OLD Value</summary>
+        public Action<int, T> OnSet;
+
+        /// <summary>This is called after the item is removed with index and OLD Value</summary>
+        public Action<int, T> OnRemove;
+
+        /// <summary>This is called before the list is cleared so the list can be iterated</summary>
+        public Action OnClear;
+
+        // Deprecated 2024-03-23
+        [Obsolete("Use individual Actions, which pass OLD values where appropriate, instead.")]
         public Action<Operation, int, T, T> Callback;
 
         readonly IList<T> objects;
@@ -85,7 +102,28 @@ namespace Mirror
                 OnDirty?.Invoke();
             }
 
+            switch (op)
+            {
+                case Operation.OP_ADD:
+                    OnAdd?.Invoke(itemIndex);
+                    break;
+                case Operation.OP_INSERT:
+                    OnInsert?.Invoke(itemIndex);
+                    break;
+                case Operation.OP_SET:
+                    OnSet?.Invoke(itemIndex, oldItem);
+                    break;
+                case Operation.OP_REMOVEAT:
+                    OnRemove?.Invoke(itemIndex, oldItem);
+                    break;
+                case Operation.OP_CLEAR:
+                    OnClear?.Invoke();
+                    break;
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Callback?.Invoke(op, itemIndex, oldItem, newItem);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public override void OnSerializeAll(NetworkWriter writer)

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
@@ -47,6 +47,7 @@ namespace Mirror.Tests.SyncCollections
             player.item.price = 15;
             serverList[0] = player;
 
+#pragma warning disable 618 // Type or member is obsolete
             bool callbackCalled = false;
             clientList.Callback = (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
             {
@@ -56,6 +57,7 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(newItem.item.price, Is.EqualTo(15));
                 callbackCalled = true;
             };
+#pragma warning restore 618 // Type or member is obsolete
 
             SyncListTest.SerializeDeltaTo(serverList, clientList);
             Assert.IsTrue(callbackCalled);

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
@@ -97,6 +97,7 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void TestClear()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -105,16 +106,26 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_CLEAR));
                 Assert.That(clientSyncList.Count, Is.EqualTo(3));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnClear = () =>
+            {
+                actionCalled = true;
+                Assert.That(clientSyncList.Count, Is.EqualTo(3));
+            };
 
             serverSyncList.Clear();
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList, Is.EquivalentTo(new string[] { }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestInsert()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -124,11 +135,20 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(index, Is.EqualTo(0));
                 Assert.That(newItem, Is.EqualTo("yay"));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnInsert = (index) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(0));
+            };
 
             serverSyncList.Insert(0, "yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "yay", "Hello", "World", "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
@@ -142,6 +162,7 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void TestSet()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -152,17 +173,28 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo("yay"));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnSet = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
 
             serverSyncList[1] = "yay";
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList[1], Is.EqualTo("yay"));
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "Hello", "yay", "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestSetNull()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -173,15 +205,30 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo(null));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnSet = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
 
             serverSyncList[1] = null;
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList[1], Is.EqualTo(null));
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "Hello", null, "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
 
+#pragma warning disable 618 // Type or member is obsolete
             // clear callback so we don't get called again
             clientSyncList.Callback = null;
+#pragma warning restore 618 // Type or member is obsolete
+
+            // clear handlers so we don't get called again
+            clientSyncList.OnSet = null;
 
             serverSyncList[1] = "yay";
             SerializeDeltaTo(serverSyncList, clientSyncList);
@@ -191,6 +238,7 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void TestRemoveAll()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -201,12 +249,22 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.Not.EqualTo("!"));
                 Assert.That(newItem, Is.EqualTo(default(string)));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnRemove = (index, item) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(0));
+                Assert.That(item, Is.Not.EqualTo("!"));
+            };
 
             // This will remove "Hello" and "World"
             serverSyncList.RemoveAll(entry => entry.Contains("l"));
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
@@ -220,6 +278,7 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void TestRemoveAt()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -229,17 +288,28 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(index, Is.EqualTo(1));
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo(default(string)));
+            };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnRemove = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
             };
 
             serverSyncList.RemoveAt(1);
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "Hello", "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void TestRemove()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
@@ -250,11 +320,21 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo(default(string)));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnRemove = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
 
             serverSyncList.Remove("World");
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(clientSyncList, Is.EquivalentTo(new[] { "Hello", "!" }));
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
@@ -362,8 +442,8 @@ namespace Mirror.Tests.SyncCollections
         [Test]
         public void CallbackTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
                 called = true;
@@ -373,18 +453,27 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo(default(string)));
                 Assert.That(newItem, Is.EqualTo("yay"));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnAdd = (index) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(3));
+                Assert.That(clientSyncList[index], Is.EqualTo("yay"));
+            };
 
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
-
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void CallbackRemoveTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
                 called = true;
@@ -393,17 +482,27 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo(default(string)));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnRemove = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
+
             serverSyncList.Remove("World");
             SerializeDeltaTo(serverSyncList, clientSyncList);
-
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]
         public void CallbackRemoveAtTest()
         {
+#pragma warning disable 618 // Type or member is obsolete
             bool called = false;
-
             clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
                 called = true;
@@ -413,11 +512,20 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(newItem, Is.EqualTo(default(string)));
             };
+#pragma warning restore 618 // Type or member is obsolete
+
+            bool actionCalled = false;
+            clientSyncList.OnRemove = (index, oldItem) =>
+            {
+                actionCalled = true;
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
 
             serverSyncList.RemoveAt(1);
             SerializeDeltaTo(serverSyncList, clientSyncList);
-
             Assert.That(called, Is.True);
+            Assert.That(actionCalled, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
- Set and Remove Actions pass **OLD** item
- Deprecates Callback Action

With the new Set and Remove Actions, users will be able to do work with the previous values, while accessing the new values by the dictionary key.