### PR TITLE
fix(NetworkAnimator): Default animatorSpeed to 1

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -31,11 +31,12 @@ namespace Mirror
         public Animator animator;
 
         /// <summary>
-        /// Syncs animator.speed
+        /// Syncs animator.speed.
+        /// Default to 1 because Animator.speed defaults to 1.
         /// </summary>
         [SyncVar(hook = nameof(OnAnimatorSpeedChanged))]
-        float animatorSpeed;
-        float previousSpeed;
+        float animatorSpeed = 1f;
+        float previousSpeed = 1f;
 
         // Note: not an object[] array because otherwise initialization is real annoying
         int[] lastIntParameters;


### PR DESCRIPTION
- Animator.speed default is 1, not zero

This ensures that if animatorSpeed is set to zero at runtime the hook fires appropriately, and doesn't fire erroneously when it's 1.

Fixes: #3793