### PR TITLE
feat(MoveToAssetsFolder): Editor Script Moves ScriptTemplates to Assets

### DIFF
--- a/Assets/ScriptTemplates/Editor.meta
+++ b/Assets/ScriptTemplates/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96993aced46357f4d9dbda89e40eabad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptTemplates/Editor/MoveToAssetsFolder.cs
+++ b/Assets/ScriptTemplates/Editor/MoveToAssetsFolder.cs
@@ -1,0 +1,42 @@
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public class MoveToAssetsFolder
+{
+    const string FirstTimeKey = "MOVE_SCRIPT_TEMPLATES_HAS_RUN";
+    const string targetFolder = "ScriptTemplates";
+    const string targetPath = "Assets/ScriptTemplates";
+
+    static MoveToAssetsFolder()
+    {
+        if (!SessionState.GetBool(FirstTimeKey, false))
+        {
+            FindAndMoveScriptTemplatesFolder();
+            SessionState.SetBool(FirstTimeKey, true);
+        }
+    }
+
+    static void FindAndMoveScriptTemplatesFolder()
+    {
+        string[] guids = AssetDatabase.FindAssets(targetFolder, null);
+        foreach (string guid in guids)
+        {
+            string path = AssetDatabase.GUIDToAssetPath(guid);
+
+            // Check if it's a folder and not some random asset
+            if (AssetDatabase.IsValidFolder(path))
+            {
+                // Ensure exact match of the name and that it's not in the Assets folder already
+                string folderName = System.IO.Path.GetFileName(path);
+                if (folderName == targetFolder && !path.StartsWith(targetPath))
+                {
+                    AssetDatabase.MoveAsset(path, targetPath);
+                    Debug.LogFormat(LogType.Log, LogOption.NoStacktrace, null, $"Moved {targetFolder} to Assets folder.");
+                }
+            }
+        }
+
+        AssetDatabase.Refresh();
+    }
+}

--- a/Assets/ScriptTemplates/Editor/MoveToAssetsFolder.cs.meta
+++ b/Assets/ScriptTemplates/Editor/MoveToAssetsFolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e383132f744a8c1448807b71fa31f7ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Ensures ScriptTemplates folder is in Assets root
- Allows ScriptTemplates folder to be included in Asset Store package under Mirror folder
- Only runs once when Unity first loads project via SessionState flag