### PR TITLE
fix(NetworkServer): Spawn for owner client even when Force Hidden

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1710,6 +1710,11 @@ namespace Mirror
                 {
                     AddAllReadyServerConnectionsToObservers(identity);
                 }
+                else if (identity.connectionToClient != null)
+                {
+                    // force hidden, but add owner connection
+                    identity.AddObserver(identity.connectionToClient);
+                }
             }
         }
 


### PR DESCRIPTION
Interest Management does this in Rebuild, but without IM involved, we need to handle this case in RebuildObserversDefault