### PR TITLE
fix(WeaverAssembler): Silence Obsolete Warning

### DIFF
--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverAssembler.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverAssembler.cs
@@ -93,11 +93,13 @@ namespace Mirror.Weaver.Tests
 
         public static void Build(Action<string> OnWarning, Action<string> OnError)
         {
+#pragma warning disable 618
             AssemblyBuilder assemblyBuilder = new AssemblyBuilder(Path.Combine(OutputDirectory, OutputFile), SourceFiles.ToArray())
             {
                 // "The type 'MonoBehaviour' is defined in an assembly that is not referenced"
                 referencesOptions = ReferencesOptions.UseEngineModules
             };
+#pragma warning restore 618
             if (AllowUnsafe)
             {
                 assemblyBuilder.compilerOptions.AllowUnsafeCode = true;


### PR DESCRIPTION
We have #3630 for this...silence warning until Unity tells us what to use instead.