### PR TITLE
breaking: Transport.GetServerClientAddress(connId) => Transport.OnServerConnected(connId, address)

### DIFF
--- a/Assets/Mirror/Core/LocalConnectionToClient.cs
+++ b/Assets/Mirror/Core/LocalConnectionToClient.cs
@@ -12,9 +12,7 @@ namespace Mirror
         // packet queue
         internal readonly Queue<NetworkWriterPooled> queue = new Queue<NetworkWriterPooled>();
 
-        public LocalConnectionToClient() : base(LocalConnectionId) {}
-
-        public override string address => "localhost";
+        public LocalConnectionToClient() : base(LocalConnectionId, "localhost") {}
 
         internal override void Send(ArraySegment<byte> segment, int channelId = Channels.Reliable)
         {

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -634,8 +634,9 @@ namespace Mirror
         }
 
         // transport events ////////////////////////////////////////////////////
-        // called by transport
-        static void OnTransportConnected(int connectionId)
+        // called by transport.
+        // address is the (IP) address without port. useful for IP bans etc.
+        static void OnTransportConnected(int connectionId, string address)
         {
             // Debug.Log($"Server accepted client:{connectionId}");
 
@@ -665,7 +666,7 @@ namespace Mirror
             if (connections.Count < maxConnections)
             {
                 // add connection
-                NetworkConnectionToClient conn = new NetworkConnectionToClient(connectionId);
+                NetworkConnectionToClient conn = new NetworkConnectionToClient(connectionId, address);
                 OnConnected(conn);
             }
             else

--- a/Assets/Mirror/Core/Transport.cs
+++ b/Assets/Mirror/Core/Transport.cs
@@ -3,6 +3,9 @@
 // Connecting:
 //   * Transports are responsible to call either OnConnected || OnDisconnected
 //     in a certain time after a Connect was called. It can not end in limbo.
+//   * OnConnected should always pass the connection address.
+//     This makes threaded transports easier.
+//     Otherwise we would need to keep a main thread connections copy.
 //
 // Disconnecting:
 //   * Connections might disconnect voluntarily by the other end.
@@ -67,7 +70,8 @@ namespace Mirror
 
         // server //////////////////////////////////////////////////////////////
         /// <summary>Called by Transport when a new client connected to the server.</summary>
-        public Action<int> OnServerConnected;
+        // parameters: <connectionId, address> to pass address directly instead of having a separate ServerGetClientAddress() function.
+        public Action<int, string> OnServerConnected;
 
         /// <summary>Called by Transport when the server received a message from a client.</summary>
         public Action<int, ArraySegment<byte>, int> OnServerDataReceived;
@@ -131,6 +135,8 @@ namespace Mirror
 
         /// <summary>Get a client's address on the server.</summary>
         // Can be useful for Game Master IP bans etc.
+        // DEPRECATED 2024-05-16
+        [Obsolete("Transport.ServerGetClientAddress() was deprecated. Each connection's address is now passed only once in OnServerConnected instead.")]
         public abstract string ServerGetClientAddress(int connectionId);
 
         /// <summary>Stop listening and disconnect all connections.</summary>

--- a/Assets/Mirror/Tests/Common/FakeNetworkConnectionToClient.cs
+++ b/Assets/Mirror/Tests/Common/FakeNetworkConnectionToClient.cs
@@ -4,8 +4,7 @@ namespace Mirror.Tests
 {
     public class FakeNetworkConnectionToClient : NetworkConnectionToClient
     {
-        public FakeNetworkConnectionToClient() : base(1) {}
-        public override string address => "Test";
+        public FakeNetworkConnectionToClient() : base(1, "localhost") {}
         public override void Disconnect() {}
         internal override void Send(ArraySegment<byte> segment, int channelId = 0) {}
     }

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -201,7 +201,7 @@ namespace Mirror.Tests
                     case EventType.Connected:
                         Debug.Log("MemoryTransport Server Message: Connected");
                         // event might be null in tests if no NetworkClient is used.
-                        OnServerConnected?.Invoke(message.connectionId);
+                        OnServerConnected?.Invoke(message.connectionId, "localhost");
                         break;
                     case EventType.Data:
                         Debug.Log($"MemoryTransport Server Message: Data: {BitConverter.ToString(message.data)}");

--- a/Assets/Mirror/Tests/Common/MemoryTransport.cs
+++ b/Assets/Mirror/Tests/Common/MemoryTransport.cs
@@ -173,6 +173,7 @@ namespace Mirror.Tests
             serverActive = false;
         }
 
+        [Obsolete("Transport.ServerGetClientAddress() was deprecated. Each connection's address is now passed only once in OnServerConnected instead.")]
         public override string ServerGetClientAddress(int connectionId) => string.Empty;
         public override void ServerStop()
         {

--- a/Assets/Mirror/Tests/Editor/InterestManagement/InterestManagementTests_Common.cs
+++ b/Assets/Mirror/Tests/Editor/InterestManagement/InterestManagementTests_Common.cs
@@ -21,7 +21,7 @@ namespace Mirror.Tests.InterestManagement
 
             // A with connectionId = 0x0A, netId = 0xAA
             CreateNetworked(out gameObjectA, out identityA);
-            connectionA = new NetworkConnectionToClient(0x0A);
+            connectionA = new NetworkConnectionToClient(0x0A, "");
             connectionA.isAuthenticated = true;
             connectionA.isReady = true;
             connectionA.identity = identityA;
@@ -29,7 +29,7 @@ namespace Mirror.Tests.InterestManagement
 
             // B
             CreateNetworked(out gameObjectB, out identityB);
-            connectionB = new NetworkConnectionToClient(0x0B);
+            connectionB = new NetworkConnectionToClient(0x0B, "");
             connectionB.isAuthenticated = true;
             connectionB.isReady = true;
             connectionB.identity = identityB;

--- a/Assets/Mirror/Tests/Editor/NetworkConnection/NetworkConnectionToClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkConnection/NetworkConnectionToClientTests.cs
@@ -34,7 +34,7 @@ namespace Mirror.Tests.NetworkConnections
         public void Send_BatchesUntilUpdate()
         {
             // create connection and send
-            NetworkConnectionToClient connection = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(42, "");
             NetworkTime.PingInterval = float.MaxValue; // disable ping for this test
             byte[] message = {0x01, 0x02};
             connection.Send(new ArraySegment<byte>(message));
@@ -63,7 +63,7 @@ namespace Mirror.Tests.NetworkConnections
             const int BatchHeader = 8;
 
             // create connection
-            NetworkConnectionToClient connection = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(42, "");
             NetworkTime.PingInterval = float.MaxValue; // disable ping for this test
 
             // send and update big message

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
@@ -123,11 +123,11 @@ namespace Mirror.Tests.NetworkIdentities
             identity.OnStartServer();
 
             // add an observer connection
-            NetworkConnectionToClient connection = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient connection = new NetworkConnectionToClient(42, "");
             identity.observers[connection.connectionId] = connection;
 
             // RemoveObserver with invalid connection should do nothing
-            identity.RemoveObserver(new NetworkConnectionToClient(43));
+            identity.RemoveObserver(new NetworkConnectionToClient(43, ""));
             Assert.That(identity.observers.Count, Is.EqualTo(1));
 
             // RemoveObserver with existing connection should remove it
@@ -324,7 +324,7 @@ namespace Mirror.Tests.NetworkIdentities
             // another connection
             // error log is expected
             LogAssert.ignoreFailingMessages = true;
-            result = identity.AssignClientAuthority(new NetworkConnectionToClient(43));
+            result = identity.AssignClientAuthority(new NetworkConnectionToClient(43, ""));
             LogAssert.ignoreFailingMessages = false;
             Assert.That(result, Is.False);
             Assert.That(identity.connectionToClient, Is.EqualTo(owner));
@@ -552,8 +552,8 @@ namespace Mirror.Tests.NetworkIdentities
             CreateNetworked(out GameObject _, out NetworkIdentity identity);
 
             // create some connections
-            NetworkConnectionToClient connection1 = new NetworkConnectionToClient(42);
-            NetworkConnectionToClient connection2 = new NetworkConnectionToClient(43);
+            NetworkConnectionToClient connection1 = new NetworkConnectionToClient(42, "");
+            NetworkConnectionToClient connection2 = new NetworkConnectionToClient(43, "");
 
             // call AddObservers
             identity.AddObserver(connection1);
@@ -565,7 +565,7 @@ namespace Mirror.Tests.NetworkIdentities
             Assert.That(identity.observers[connection2.connectionId], Is.EqualTo(connection2));
 
             // adding a duplicate connectionId shouldn't overwrite the original
-            NetworkConnectionToClient duplicate = new NetworkConnectionToClient(connection1.connectionId);
+            NetworkConnectionToClient duplicate = new NetworkConnectionToClient(connection1.connectionId, "");
             identity.AddObserver(duplicate);
             Assert.That(identity.observers.Count, Is.EqualTo(2));
             Assert.That(identity.observers.ContainsKey(connection1.connectionId));
@@ -583,8 +583,8 @@ namespace Mirror.Tests.NetworkIdentities
             identity.OnStartServer();
 
             // add some observers
-            identity.observers[42] = new NetworkConnectionToClient(42);
-            identity.observers[43] = new NetworkConnectionToClient(43);
+            identity.observers[42] = new NetworkConnectionToClient(42, "");
+            identity.observers[43] = new NetworkConnectionToClient(43, "");
 
             // call ClearObservers
             identity.ClearObservers();
@@ -632,9 +632,9 @@ namespace Mirror.Tests.NetworkIdentities
             identity.isClient = true;
             // creates .observers and generates a netId
             identity.OnStartServer();
-            identity.connectionToClient = new NetworkConnectionToClient(1);
+            identity.connectionToClient = new NetworkConnectionToClient(1, "");
             identity.connectionToServer = new NetworkConnectionToServer();
-            identity.observers[43] = new NetworkConnectionToClient(2);
+            identity.observers[43] = new NetworkConnectionToClient(2, "");
 
             // mark for reset and reset
             identity.ResetState();

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -67,11 +67,11 @@ namespace Mirror.Tests.NetworkServers
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
 
             // connect first: should work
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
 
             // connect second: should fail
-            transport.OnServerConnected.Invoke(43);
+            transport.OnServerConnected.Invoke(43, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
         }
 
@@ -84,7 +84,7 @@ namespace Mirror.Tests.NetworkServers
 
             // listen & connect
             NetworkServer.Listen(1);
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
             Assert.That(connectCalled, Is.True);
         }
 
@@ -97,7 +97,7 @@ namespace Mirror.Tests.NetworkServers
 
             // listen & connect
             NetworkServer.Listen(1);
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
 
             // disconnect
             transport.OnServerDisconnected.Invoke(42);
@@ -112,12 +112,12 @@ namespace Mirror.Tests.NetworkServers
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
 
             // connect first
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             Assert.That(NetworkServer.connections.ContainsKey(42), Is.True);
 
             // connect second
-            transport.OnServerConnected.Invoke(43);
+            transport.OnServerConnected.Invoke(43, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(2));
             Assert.That(NetworkServer.connections.ContainsKey(43), Is.True);
 
@@ -144,7 +144,7 @@ namespace Mirror.Tests.NetworkServers
             // connect with connectionId == 0 should fail
             // (it will show an error message, which is expected)
             LogAssert.ignoreFailingMessages = true;
-            transport.OnServerConnected.Invoke(0);
+            transport.OnServerConnected.Invoke(0, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
             LogAssert.ignoreFailingMessages = false;
         }
@@ -156,12 +156,12 @@ namespace Mirror.Tests.NetworkServers
             NetworkServer.Listen(2);
 
             // connect first
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             NetworkConnectionToClient original = NetworkServer.connections[42];
 
             // connect duplicate - shouldn't overwrite first one
-            transport.OnServerConnected.Invoke(42);
+            transport.OnServerConnected.Invoke(42, "");
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             Assert.That(NetworkServer.connections[42], Is.EqualTo(original));
         }
@@ -230,13 +230,13 @@ namespace Mirror.Tests.NetworkServers
             NetworkServer.Listen(1);
 
             // add first connection
-            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42, "");
             Assert.That(NetworkServer.AddConnection(conn42), Is.True);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             Assert.That(NetworkServer.connections[42], Is.EqualTo(conn42));
 
             // add second connection
-            NetworkConnectionToClient conn43 = new NetworkConnectionToClient(43);
+            NetworkConnectionToClient conn43 = new NetworkConnectionToClient(43, "");
             Assert.That(NetworkServer.AddConnection(conn43), Is.True);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(2));
             Assert.That(NetworkServer.connections[42], Is.EqualTo(conn42));
@@ -250,13 +250,13 @@ namespace Mirror.Tests.NetworkServers
             NetworkServer.Listen(1);
 
             // add a connection
-            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42, "");
             Assert.That(NetworkServer.AddConnection(conn42), Is.True);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             Assert.That(NetworkServer.connections[42], Is.EqualTo(conn42));
 
             // add duplicate connectionId
-            NetworkConnectionToClient connDup = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient connDup = new NetworkConnectionToClient(42, "");
             Assert.That(NetworkServer.AddConnection(connDup), Is.False);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
             Assert.That(NetworkServer.connections[42], Is.EqualTo(conn42));
@@ -269,7 +269,7 @@ namespace Mirror.Tests.NetworkServers
             NetworkServer.Listen(1);
 
             // add connection
-            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42, "");
             Assert.That(NetworkServer.AddConnection(conn42), Is.True);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
 
@@ -285,7 +285,7 @@ namespace Mirror.Tests.NetworkServers
             NetworkServer.Listen(1);
 
             // add connection
-            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42);
+            NetworkConnectionToClient conn42 = new NetworkConnectionToClient(42, "");
             NetworkServer.AddConnection(conn42);
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(1));
 

--- a/Assets/Mirror/Tests/Editor/Transports/EncryptionTransportTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transports/EncryptionTransportTransportTest.cs
@@ -122,6 +122,7 @@ namespace Mirror.Tests.Transports
             inner.Received(1).ServerStop();
         }
 
+ #pragma warning disable CS0618
         [Test]
         [TestCase(0, "tcp4://localhost:7777")]
         [TestCase(19, "tcp4://example.com:7777")]
@@ -133,8 +134,8 @@ namespace Mirror.Tests.Transports
 
             inner.Received(1).ServerGetClientAddress(id);
             inner.Received(0).ServerGetClientAddress(Arg.Is<int>(x => x != id));
-
         }
+ #pragma warning restore CS0618
 
         [Test]
         [TestCase("tcp4://localhost:7777")]

--- a/Assets/Mirror/Tests/Editor/Transports/MiddlewareTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transports/MiddlewareTransportTest.cs
@@ -298,7 +298,7 @@ namespace Mirror.Tests.Transports
         public void TestServerConnectedCallback(int id)
         {
             int called = 0;
-            middleware.OnServerConnected = (i) =>
+            middleware.OnServerConnected = (i, addr) =>
             {
                 called++;
                 Assert.That(i, Is.EqualTo(id));
@@ -306,10 +306,10 @@ namespace Mirror.Tests.Transports
             // start to give callback to inner
             middleware.ServerStart();
 
-            inner.OnServerConnected.Invoke(id);
+            inner.OnServerConnected.Invoke(id, "");
             Assert.That(called, Is.EqualTo(1));
 
-            inner.OnServerConnected.Invoke(id);
+            inner.OnServerConnected.Invoke(id, "");
             Assert.That(called, Is.EqualTo(2));
         }
 

--- a/Assets/Mirror/Tests/Editor/Transports/MiddlewareTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transports/MiddlewareTransportTest.cs
@@ -158,6 +158,7 @@ namespace Mirror.Tests.Transports
             inner.Received(0).ServerSend(Arg.Is<int>(x => x != id), Arg.Any<ArraySegment<byte>>(), Arg.Any<int>());
         }
 
+ #pragma warning disable CS0618
         [Test]
         [TestCase(0, "tcp4://localhost:7777")]
         [TestCase(19, "tcp4://example.com:7777")]
@@ -171,6 +172,7 @@ namespace Mirror.Tests.Transports
             inner.Received(0).ServerGetClientAddress(Arg.Is<int>(x => x != id));
 
         }
+ #pragma warning restore CS0618
 
         [Test]
         [TestCase("tcp4://localhost:7777")]

--- a/Assets/Mirror/Tests/Editor/Transports/MultiplexTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transports/MultiplexTransportTest.cs
@@ -260,7 +260,7 @@ namespace Mirror.Tests.Transports
             transport.ServerStart();
             transport.ClientConnect("some.server.com");
 
-            transport.OnServerConnected    = (connId, address) => {};
+            transport.OnServerConnected    = (_,_) => {};
             transport.OnServerDisconnected = _ => {};
 
             // connect two connectionIds.

--- a/Assets/Mirror/Tests/Editor/Transports/MultiplexTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transports/MultiplexTransportTest.cs
@@ -238,7 +238,7 @@ namespace Mirror.Tests.Transports
             ArraySegment<byte> segment = new ArraySegment<byte>(data);
 
             // on connect, send a message back
-            void SendMessage(int connectionId)
+            void SendMessage(int connectionId, string address)
             {
                 transport.ServerSend(connectionId, segment, 5);
             }
@@ -247,7 +247,7 @@ namespace Mirror.Tests.Transports
             transport.OnServerConnected = SendMessage;
             transport.ServerStart();
 
-            transport1.OnServerConnected.Invoke(1);
+            transport1.OnServerConnected.Invoke(1, "");
 
             transport1.Received().ServerSend(1, segment, 5);
         }
@@ -260,14 +260,14 @@ namespace Mirror.Tests.Transports
             transport.ServerStart();
             transport.ClientConnect("some.server.com");
 
-            transport.OnServerConnected    = _ => {};
+            transport.OnServerConnected    = (connId, address) => {};
             transport.OnServerDisconnected = _ => {};
 
             // connect two connectionIds.
             // one of them very large to prevent
             // https://github.com/vis2k/Mirror/issues/3280
-            transport1.OnServerConnected(10);
-            transport2.OnServerConnected(int.MaxValue);
+            transport1.OnServerConnected(10, "");
+            transport2.OnServerConnected(int.MaxValue, "");
 
             byte[] data = { 1, 2, 3 };
             ArraySegment<byte> segment = new ArraySegment<byte>(data);

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -95,7 +95,7 @@ namespace Mirror.Tests.Runtime
             NetworkServer.disconnectInactiveTimeout = 1;
 
             GameObject remotePlayer = new GameObject("RemotePlayer", typeof(NetworkIdentity));
-            NetworkConnectionToClient remoteConnection = new NetworkConnectionToClient(1);
+            NetworkConnectionToClient remoteConnection = new NetworkConnectionToClient(1, "localhost");
             NetworkServer.OnConnected(remoteConnection);
             NetworkServer.AddPlayerForConnection(remoteConnection, remotePlayer);
 

--- a/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpServer.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpServer.cs
@@ -28,7 +28,7 @@ namespace Edgegap
         bool relayActive;
 
         public EdgegapKcpServer(
-            Action<int> OnConnected,
+            Action<int, IPEndPoint> OnConnected,
             Action<int, ArraySegment<byte>, KcpChannel> OnData,
             Action<int> OnDisconnected,
             Action<int, ErrorCode, string> OnError,

--- a/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
@@ -60,7 +60,7 @@ namespace Edgegap
 
             // server
             server = new EdgegapKcpServer(
-                (connectionId) => OnServerConnected.Invoke(connectionId),
+                (connectionId, endPoint) => OnServerConnected.Invoke(connectionId, endPoint.PrettyAddress()),
                 (connectionId, message, channel) => OnServerDataReceived.Invoke(connectionId, message, FromKcpChannel(channel)),
                 (connectionId) => OnServerDisconnected.Invoke(connectionId),
                 (connectionId, error, reason) => OnServerError.Invoke(connectionId, ToTransportError(error), reason),

--- a/Assets/Mirror/Transports/Encryption/EncryptionTransport.cs
+++ b/Assets/Mirror/Transports/Encryption/EncryptionTransport.cs
@@ -76,7 +76,7 @@ namespace Mirror.Transports.Encryption
             }
         }
 
-        private void HandleInnerServerConnected(int connId)
+        private void HandleInnerServerConnected(int connId, string address)
         {
             Debug.Log($"[EncryptionTransport] New connection #{connId}");
             EncryptedConnection ec = null;
@@ -89,7 +89,7 @@ namespace Mirror.Transports.Encryption
                 {
                     Debug.Log($"[EncryptionTransport] Connection #{connId} is ready");
                     ServerRemoveFromPending(ec);
-                    OnServerConnected?.Invoke(connId);
+                    OnServerConnected?.Invoke(connId, address);
                 },
                 (type, msg) =>
                 {

--- a/Assets/Mirror/Transports/KCP/KcpTransport.cs
+++ b/Assets/Mirror/Transports/KCP/KcpTransport.cs
@@ -122,7 +122,7 @@ namespace kcp2k
 
             // server
             server = new KcpServer(
-                (connectionId) => OnServerConnected.Invoke(connectionId),
+                (connectionId, endPoint) => OnServerConnected.Invoke(connectionId, endPoint.PrettyAddress()),
                 (connectionId, message, channel) => OnServerDataReceived.Invoke(connectionId, message, FromKcpChannel(channel)),
                 (connectionId) => OnServerDisconnected.Invoke(connectionId),
                 (connectionId, error, reason) => OnServerError.Invoke(connectionId, ToTransportError(error), reason),

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServer.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServer.cs
@@ -18,7 +18,7 @@ namespace kcp2k
         // events are readonly, set in constructor.
         // this ensures they are always initialized when used.
         // fixes https://github.com/MirrorNetworking/Mirror/issues/3337 and more
-        protected readonly Action<int> OnConnected;
+        protected readonly Action<int, IPEndPoint> OnConnected; // connectionId, address
         protected readonly Action<int, ArraySegment<byte>, KcpChannel> OnData;
         protected readonly Action<int> OnDisconnected;
         protected readonly Action<int, ErrorCode, string> OnError;
@@ -43,7 +43,7 @@ namespace kcp2k
         public Dictionary<int, KcpServerConnection> connections =
             new Dictionary<int, KcpServerConnection>();
 
-        public KcpServer(Action<int> OnConnected,
+        public KcpServer(Action<int, IPEndPoint> OnConnected,
                          Action<int, ArraySegment<byte>, KcpChannel> OnData,
                          Action<int> OnDisconnected,
                          Action<int, ErrorCode, string> OnError,
@@ -184,6 +184,7 @@ namespace kcp2k
         }
 
         // expose the whole IPEndPoint, not just the IP address. some need it.
+        [Obsolete("KcpServer.GetClientEndPoint() isn't needed anymore. Connection endpoints are now passed in the KcpServer.OnConnected event in order to make threaded transports easier.")]
         public IPEndPoint GetClientEndPoint(int connectionId)
         {
             if (connections.TryGetValue(connectionId, out KcpServerConnection connection))
@@ -285,7 +286,8 @@ namespace kcp2k
 
                 // finally, call mirror OnConnected event
                 Log.Info($"[KCP] Server: OnConnected({connectionId})");
-                OnConnected(connectionId);
+                IPEndPoint endPoint = conn.remoteEndPoint as IPEndPoint;
+                OnConnected(connectionId, endPoint);
             }
 
             void OnDisconnectedCallback()

--- a/Assets/Mirror/Transports/Multiplex/MultiplexTransport.cs
+++ b/Assets/Mirror/Transports/Multiplex/MultiplexTransport.cs
@@ -261,12 +261,12 @@ namespace Mirror
                 int transportIndex = i;
                 Transport transport = transports[i];
 
-                transport.OnServerConnected = (originalConnectionId =>
+                transport.OnServerConnected = (originalConnectionId, originalAddress) =>
                 {
                     // invoke Multiplex event with multiplexed connectionId
                     int multiplexedId = AddToLookup(originalConnectionId, transportIndex);
-                    OnServerConnected.Invoke(multiplexedId);
-                });
+                    OnServerConnected.Invoke(multiplexedId, originalAddress);
+                };
 
                 transport.OnServerDataReceived = (originalConnectionId, data, channel) =>
                 {
@@ -282,7 +282,7 @@ namespace Mirror
                         }
                         else
                             Debug.LogWarning($"[Multiplexer] Received data for unknown connectionId={originalConnectionId} on transport={transportIndex}");
-              
+
                         return;
                     }
                     OnServerDataReceived.Invoke(multiplexedId, data, channel);
@@ -302,7 +302,7 @@ namespace Mirror
                         }
                         else
                             Debug.LogError($"[Multiplexer] Received error for unknown connectionId={originalConnectionId} on transport={transportIndex}");
-                        
+
                         return;
                     }
                     OnServerError.Invoke(multiplexedId, error, reason);
@@ -329,7 +329,7 @@ namespace Mirror
                         }
                         else
                             Debug.LogWarning($"[Multiplexer] Received disconnect for unknown connectionId={originalConnectionId} on transport={transportIndex}");
-                        
+
                         return;
                     }
                     OnServerDisconnected.Invoke(multiplexedId);

--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/SimpleWebServer.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Server/SimpleWebServer.cs
@@ -6,7 +6,7 @@ namespace Mirror.SimpleWeb
 {
     public class SimpleWebServer
     {
-        public event Action<int> onConnect;
+        public event Action<int, string> onConnect; // connectionId, address
         public event Action<int> onDisconnect;
         public event Action<int, ArraySegment<byte>> onData;
         public event Action<int, Exception> onError;
@@ -91,7 +91,8 @@ namespace Mirror.SimpleWeb
                 switch (next.type)
                 {
                     case EventType.Connected:
-                        onConnect?.Invoke(next.connId);
+                        string address = GetClientAddress(next.connId);
+                        onConnect?.Invoke(next.connId, address);
                         break;
                     case EventType.Data:
                         onData?.Invoke(next.connId, next.data.ToSegment());

--- a/Assets/Mirror/Transports/Telepathy/TelepathyTransport.cs
+++ b/Assets/Mirror/Transports/Telepathy/TelepathyTransport.cs
@@ -178,7 +178,7 @@ namespace Mirror
             // system's hook (e.g. statistics OnData) was added is to wrap
             // them all in a lambda and always call the latest hook.
             // (= lazy call)
-            server.OnConnected = (connectionId) => OnServerConnected.Invoke(connectionId);
+            server.OnConnected = (connectionId, endPoint) => OnServerConnected.Invoke(connectionId, endPoint.PrettyAddress());
             server.OnData = (connectionId, segment) => OnServerDataReceived.Invoke(connectionId, segment, Channels.Reliable);
             server.OnDisconnected = (connectionId) => OnServerDisconnected.Invoke(connectionId);
 


### PR DESCRIPTION
## Refactor Transports.

**Previously:**
```Transport.GetServerClientAddress(connId)``` needs to be called to get a connection's address.

**Now:** ```Transport.OnServerConnected``` changed from ```(connId)``` to ```(connId, address)```.

## Reasons:
- **ThreadedTransports** can't easily implement GetServerClientAddress because all the data is behind a thread that can't safely be accessed from main thread. Much easier to pass a connection's address **once** in OnConnected instead.
- **Cleaner** API. This function was always very odd, leftover from the UNET days.
- **Performance**: NetworkConnectionToClient.address is currently a getter which calls Transport.GetServerClientAddress every single time. This is way too much overhead.