### PR TITLE
fix(LatencySimulation): implement PortTransport since almost all underlying Transports are PortTransports

### DIFF
--- a/Assets/Mirror/Transports/Latency/LatencySimulation.cs
+++ b/Assets/Mirror/Transports/Latency/LatencySimulation.cs
@@ -35,7 +35,7 @@ namespace Mirror
                 if (wrap is PortTransport port)
                     return port.Port;
                 
-                Debug.LogWarning($"LatencySimulation: attempted to set Port but {wrap} is no PortTransport.");
+                Debug.LogWarning($"LatencySimulation: attempted to get Port but {wrap} is not a PortTransport.");
                 return 0;   
             }
             set

--- a/Assets/Mirror/Transports/Latency/LatencySimulation.cs
+++ b/Assets/Mirror/Transports/Latency/LatencySimulation.cs
@@ -46,7 +46,7 @@ namespace Mirror
                     return;
                 }
                 
-                Debug.LogWarning($"LatencySimulation: attempted to get Port but {wrap} is no PortTransport.");
+                Debug.LogWarning($"LatencySimulation: attempted to set Port but {wrap} is not a PortTransport.");
             }
         }
 

--- a/Assets/Mirror/Transports/Latency/LatencySimulation.cs
+++ b/Assets/Mirror/Transports/Latency/LatencySimulation.cs
@@ -22,9 +22,33 @@ namespace Mirror
 
     [HelpURL("https://mirror-networking.gitbook.io/docs/transports/latency-simulaton-transport")]
     [DisallowMultipleComponent]
-    public class LatencySimulation : Transport
+    public class LatencySimulation : Transport, PortTransport
     {
         public Transport wrap;
+
+        // implement PortTransport in case the underlying Tranpsport is a PortTransport too.
+        // otherwise gameplay code like 'if Transport is PortTransport' would completely break with Latency Simulation.
+        public ushort Port
+        {
+            get
+            {
+                if (wrap is PortTransport port)
+                    return port.Port;
+                
+                Debug.LogWarning($"LatencySimulation: attempted to set Port but {wrap} is no PortTransport.");
+                return 0;   
+            }
+            set
+            {
+                if (wrap is PortTransport port)
+                {
+                    port.Port = value;
+                    return;
+                }
+                
+                Debug.LogWarning($"LatencySimulation: attempted to get Port but {wrap} is no PortTransport.");
+            }
+        }
 
         [Header("Common")]
         // latency always needs to be applied to both channels!


### PR DESCRIPTION
Fixes a bug in a project that was trying to simulate latency.
They checked "if Transport is PortTransport" during setup, which silently broke with LatencySimulation since that's not a PortTransport.

This PR makes it a PortTransport, and warns if it isn't.
Instead of not being a PortTransport, which is wrong in 99% of the cases.