### PR TITLE
feat(NetworkServer): Improves RemovePlayerForConnectsion

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -6,6 +6,16 @@ using UnityEngine;
 
 namespace Mirror
 {
+    public enum RemovePlayerOptions
+    {
+        /// <summary>Player Object remains active on server and clients. Only ownership is removed</summary>
+        KeepActive,
+        /// <summary>Player Object is unspawned on clients but remains on server</summary>
+        Unspawn,
+        /// <summary>Player Object is destroyed on server and clients</summary>
+        Destroy
+    }
+
     /// <summary>NetworkServer handles remote connections and has a local connection for a local client.</summary>
     public static partial class NetworkServer
     {
@@ -1159,24 +1169,14 @@ namespace Mirror
                 RemovePlayerForConnection(conn, RemovePlayerOptions.Unspawn);
         }
 
-        public enum RemovePlayerOptions 
-        {
-            /// <summary>Player Object remains on server and clients. Only ownership is removed</summary>
-            DoNothing,
-            /// <summary>Player Object is unspawned on clients but remains on server</summary>
-            Unspawn,
-            /// <summary>Player Object is destroyed on server and clients</summary>
-            Destroy
-        }
-
         /// <summary>Removes player object for the connection. Options to keep the object in play, unspawn it, or destroy it.</summary>
-        public static void RemovePlayerForConnection(NetworkConnectionToClient conn, RemovePlayerOptions removeOptions = RemovePlayerOptions.DoNothing)
+        public static void RemovePlayerForConnection(NetworkConnectionToClient conn, RemovePlayerOptions removeOptions = RemovePlayerOptions.KeepActive)
         {
             if (conn.identity == null) return;
 
             switch (removeOptions)
             {
-                case RemovePlayerOptions.DoNothing:
+                case RemovePlayerOptions.KeepActive:
                     conn.identity.connectionToClient = null;
                     conn.owned.Remove(conn.identity);
                     SendChangeOwnerMessage(conn.identity, conn);

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1170,7 +1170,7 @@ namespace Mirror
         }
 
         /// <summary>Replaces connection's player object. The old object is not destroyed.</summary>
-        public static void RemovePlayerForConnection(NetworkConnectionToClient conn, RemovePlayerOptions removeOptions)
+        public static void RemovePlayerForConnection(NetworkConnectionToClient conn, RemovePlayerOptions removeOptions = RemovePlayerOptions.DoNothing)
         {
             if (conn.identity == null) return;
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1157,8 +1157,6 @@ namespace Mirror
                 RemovePlayerForConnection(conn, RemovePlayerOptions.Destroy);
             else
                 RemovePlayerForConnection(conn, RemovePlayerOptions.Unspawn);
-
-            conn.identity = null;
         }
 
         public enum RemovePlayerOptions 
@@ -1190,6 +1188,8 @@ namespace Mirror
                     Destroy(conn.identity.gameObject);
                     break;
             }
+
+            conn.identity = null;
         }
 
         // ready ///////////////////////////////////////////////////////////////
@@ -1386,7 +1386,7 @@ namespace Mirror
             {
                 netId = identity.netId,
                 isOwner = identity.connectionToClient == conn,
-                isLocalPlayer = conn.identity == identity
+                isLocalPlayer = (conn.identity == identity && identity.connectionToClient == conn)
             });
         }
 

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1169,7 +1169,7 @@ namespace Mirror
             Destroy
         }
 
-        /// <summary>Replaces connection's player object. The old object is not destroyed.</summary>
+        /// <summary>Removes player object for the connection. Options to keep the object in play, unspawn it, or destroy it.</summary>
         public static void RemovePlayerForConnection(NetworkConnectionToClient conn, RemovePlayerOptions removeOptions = RemovePlayerOptions.DoNothing)
         {
             if (conn.identity == null) return;

--- a/Assets/Mirror/Examples/AdditiveLevels/Scripts/Portal.cs
+++ b/Assets/Mirror/Examples/AdditiveLevels/Scripts/Portal.cs
@@ -69,7 +69,7 @@ namespace Mirror.Examples.AdditiveLevels
                 yield return new WaitForSeconds(AdditiveLevelsNetworkManager.singleton.fadeInOut.GetDuration());
 
                 // Remove player after fader has completed
-                NetworkServer.RemovePlayerForConnection(conn, NetworkServer.RemovePlayerOptions.Unspawn);
+                NetworkServer.RemovePlayerForConnection(conn, RemovePlayerOptions.Unspawn);
 
                 // reposition player on server and client
                 player.transform.position = startPosition;

--- a/Assets/Mirror/Examples/AdditiveLevels/Scripts/Portal.cs
+++ b/Assets/Mirror/Examples/AdditiveLevels/Scripts/Portal.cs
@@ -69,7 +69,7 @@ namespace Mirror.Examples.AdditiveLevels
                 yield return new WaitForSeconds(AdditiveLevelsNetworkManager.singleton.fadeInOut.GetDuration());
 
                 // Remove player after fader has completed
-                NetworkServer.RemovePlayerForConnection(conn, false);
+                NetworkServer.RemovePlayerForConnection(conn, NetworkServer.RemovePlayerOptions.Unspawn);
 
                 // reposition player on server and client
                 player.transform.position = startPosition;

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
@@ -279,22 +279,22 @@ namespace Mirror.Examples.MultipleMatch
 
             if (!disconnected)
             {
-                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
+                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player1.connectionToClient);
 
-                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
+                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player2.connectionToClient);
             }
             else if (conn == player1.connectionToClient)
             {
                 // player1 has disconnected - send player2 back to Lobby
-                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
+                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player2.connectionToClient);
             }
             else if (conn == player2.connectionToClient)
             {
                 // player2 has disconnected - send player1 back to Lobby
-                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
+                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player1.connectionToClient);
             }
 

--- a/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
+++ b/Assets/Mirror/Examples/MultipleMatches/Scripts/MatchController.cs
@@ -279,22 +279,22 @@ namespace Mirror.Examples.MultipleMatch
 
             if (!disconnected)
             {
-                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, true);
+                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player1.connectionToClient);
 
-                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, true);
+                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player2.connectionToClient);
             }
             else if (conn == player1.connectionToClient)
             {
                 // player1 has disconnected - send player2 back to Lobby
-                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, true);
+                NetworkServer.RemovePlayerForConnection(player2.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player2.connectionToClient);
             }
             else if (conn == player2.connectionToClient)
             {
                 // player2 has disconnected - send player1 back to Lobby
-                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, true);
+                NetworkServer.RemovePlayerForConnection(player1.connectionToClient, NetworkServer.RemovePlayerOptions.Destroy);
                 CanvasController.waitingConnections.Add(player1.connectionToClient);
             }
 

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -1306,7 +1306,7 @@ namespace Mirror.Tests.NetworkServers
                 connectionToClient);
 
             // set it to not be owned by this connection anymore
-            NetworkServer.RemovePlayerForConnection(connectionToClient, false);
+            NetworkServer.RemovePlayerForConnection(connectionToClient, NetworkServer.RemovePlayerOptions.DoNothing);
             ProcessMessages();
 
             // should call OnStopLocalPlayer on client

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -1306,7 +1306,7 @@ namespace Mirror.Tests.NetworkServers
                 connectionToClient);
 
             // set it to not be owned by this connection anymore
-            NetworkServer.RemovePlayerForConnection(connectionToClient, NetworkServer.RemovePlayerOptions.DoNothing);
+            NetworkServer.RemovePlayerForConnection(connectionToClient, RemovePlayerOptions.KeepActive);
             ProcessMessages();
 
             // should call OnStopLocalPlayer on client

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -43,7 +43,7 @@ namespace Mirror.Tests.Runtime
             NetworkServer.RemovePlayerForConnection(NetworkServer.localConnection, RemovePlayerOptions.KeepActive);
             yield return null;
 
-            Assert.That(player, Is.Not.Null, "Player should be not be destroyed");
+            Assert.That(player, Is.Not.Null, "Player should not be destroyed");
             Assert.That(NetworkServer.localConnection.identity == null, "identity should be null");
 
             // respawn player

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -40,7 +40,7 @@ namespace Mirror.Tests.Runtime
             CreateNetworkedAndSpawnPlayer(out GameObject player, out _, NetworkServer.localConnection);
 
             // remove player for connection, wait 1 frame for ownership removal
-            NetworkServer.RemovePlayerForConnection(NetworkServer.localConnection, NetworkServer.RemovePlayerOptions.DoNothing);
+            NetworkServer.RemovePlayerForConnection(NetworkServer.localConnection, RemovePlayerOptions.KeepActive);
             yield return null;
 
             Assert.That(player, Is.Not.Null, "Player should be not be destroyed");

--- a/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerRuntimeTest.cs
@@ -39,8 +39,8 @@ namespace Mirror.Tests.Runtime
             // create spawned player
             CreateNetworkedAndSpawnPlayer(out GameObject player, out _, NetworkServer.localConnection);
 
-            // remove player for connection, wait 1 frame to unspawn
-            NetworkServer.RemovePlayerForConnection(NetworkServer.localConnection, false);
+            // remove player for connection, wait 1 frame for ownership removal
+            NetworkServer.RemovePlayerForConnection(NetworkServer.localConnection, NetworkServer.RemovePlayerOptions.DoNothing);
             yield return null;
 
             Assert.That(player, Is.Not.Null, "Player should be not be destroyed");


### PR DESCRIPTION
- Replaces `destroyServerObject` with `RemovePlayerOptions`
- Option to keep the player object on server and clients
- Obsoletes old method by calling new method with correct option
- Examples and Tests updated