### PR TITLE
Velocity Iterations on NM, Drag on Cube prefabs.

### DIFF
--- a/Assets/Mirror/Examples/StackedPrediction/NetworkManagerStackedPrediction.cs
+++ b/Assets/Mirror/Examples/StackedPrediction/NetworkManagerStackedPrediction.cs
@@ -11,8 +11,9 @@ namespace Mirror.Examples.PredictionBenchmark
         public float interleave = 1;
 
         // 500 objects need around 100 iterations to be stable
-        [Tooltip("Stacked Cubes are only stable if solver iterations are high enough!")]
+        [Tooltip("Stacked Cubes are only stable if solver iterations are high enough!\nDefault is 1, max is 255.")]
         public int solverIterations = 200;
+        public int solverVelocityIterations = 1;
 
         public override void Awake()
         {
@@ -25,6 +26,10 @@ namespace Mirror.Examples.PredictionBenchmark
             int before = Physics.defaultSolverIterations;
             Physics.defaultSolverIterations = solverIterations;
             Debug.Log($"Physics.defaultSolverIterations: {before} -> {Physics.defaultSolverIterations}");
+
+            before = Physics.defaultSolverVelocityIterations;
+            Physics.defaultSolverVelocityIterations = solverVelocityIterations;
+            Debug.Log($"Physics.defaultSolverVelocityIterations: {before} -> {Physics.defaultSolverVelocityIterations}");
         }
 
         void SpawnAll()

--- a/Assets/Mirror/Examples/StackedPrediction/PredictedCube.prefab
+++ b/Assets/Mirror/Examples/StackedPrediction/PredictedCube.prefab
@@ -109,7 +109,7 @@ Rigidbody:
   m_GameObject: {fileID: 1161087258037110271}
   serializedVersion: 2
   m_Mass: 1
-  m_Drag: 0
+  m_Drag: 0.05
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0


### PR DESCRIPTION
Minor drag on cube prefabs, to stop them from indefinitely moving/rotating.
(highly recommend to not have 0 drag on released games, unity default Rigidbody drag is 0, take note everyone :D )

Velocity Iterations added to NetworkManager(StackedPrediction), next to regular Iterations, left as Unity default 1, alerts users to the setting that they can then adjust themselves.
Added tooltip note that unity default is 1, and max is 255.

<img width="243" alt="Screenshot 2024-06-19 at 10 27 34" src="https://github.com/MirrorNetworking/Mirror/assets/57072365/59e43416-8bef-4230-b4d2-3eba5e907945">

<img width="219" alt="Screenshot 2024-06-19 at 10 27 27" src="https://github.com/MirrorNetworking/Mirror/assets/57072365/418df806-112b-415e-bf79-c87e45f66b03">
