### PR TITLE
fix: #3832 NetworkServer.Destroy now doesn't call ResetState for prefabs, fixes isServer flag always being false in OnDestroy

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1698,17 +1698,28 @@ namespace Mirror
                 return;
             }
 
-            // first, we unspawn it on clients and server
-            UnSpawn(obj);
+            // get the NetworkIdentity component first
+            if (!GetNetworkIdentity(obj, out NetworkIdentity identity))
+            {
+                Debug.LogWarning($"NetworkServer.Destroy() called on {obj.name} which doesn't have a NetworkIdentity component.");
+                return;
+            }
 
-            // additionally, if it's a prefab then we destroy it completely.
+            // is this a scene object?
+            // then we simply unspawn & reset it so it can still be spawned again.
             // we never destroy scene objects on server or on client, since once
             // they are gone, they are gone forever and can't be instantiate again.
             // for example, server may Destroy() a scene object and once a match
             // restarts, the scene objects would be gone from the new match.
-            if (GetNetworkIdentity(obj, out NetworkIdentity identity) &&
-                identity.sceneId == 0)
+            if (identity.sceneId != 0)
             {
+                UnSpawn(obj);
+            }
+            // is this a prefab?
+            // then we destroy it completely.
+            else
+            {
+                UnSpawn(obj);
                 identity.destroyCalled = true;
 
                 // Destroy if application is running

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1592,14 +1592,12 @@ namespace Mirror
             RebuildObservers(identity, true);
         }
 
-        /// <summary>This takes an object that has been spawned and un-spawns it.</summary>
-        // The object will be removed from clients that it was spawned on, or
-        // the custom spawn handler function on the client will be called for
-        // the object.
-        // Unlike when calling NetworkServer.Destroy(), on the server the object
-        // will NOT be destroyed. This allows the server to re-use the object,
-        // even spawn it again later.
-        public static void UnSpawn(GameObject obj)
+        // internal Unspawn function which has the 'resetState' parameter.
+        // resetState calls .ResetState() on the object after unspawning.
+        // this is necessary for scene objects, but not for prefabs since we
+        // don't want to reset their isServer flags etc.
+        // fixes: https://github.com/MirrorNetworking/Mirror/issues/3832
+        static void UnSpawnInternal(GameObject obj, bool resetState)
         {
             // Debug.Log($"DestroyObject instance:{identity.netId}");
 
@@ -1673,9 +1671,21 @@ namespace Mirror
             identity.OnStopServer();
 
             // finally reset the state and deactivate it
-            identity.ResetState();
-            identity.gameObject.SetActive(false);
+            if (resetState)
+            {
+                identity.ResetState();
+                identity.gameObject.SetActive(false);
+            }
         }
+
+        /// <summary>This takes an object that has been spawned and un-spawns it.</summary>
+        // The object will be removed from clients that it was spawned on, or
+        // the custom spawn handler function on the client will be called for
+        // the object.
+        // Unlike when calling NetworkServer.Destroy(), on the server the object
+        // will NOT be destroyed. This allows the server to re-use the object,
+        // even spawn it again later.
+        public static void UnSpawn(GameObject obj) => UnSpawnInternal(obj, resetState: true);
 
         // destroy /////////////////////////////////////////////////////////////
         /// <summary>Destroys this object and corresponding objects on all clients.</summary>
@@ -1713,13 +1723,16 @@ namespace Mirror
             // restarts, the scene objects would be gone from the new match.
             if (identity.sceneId != 0)
             {
-                UnSpawn(obj);
+                UnSpawnInternal(obj, resetState: true);
             }
             // is this a prefab?
             // then we destroy it completely.
             else
             {
-                UnSpawn(obj);
+                // unspawn without calling ResetState.
+                // otherwise isServer/isClient flags might be reset in OnDestroy.
+                // fixes: https://github.com/MirrorNetworking/Mirror/issues/3832
+                UnSpawnInternal(obj, resetState: false);
                 identity.destroyCalled = true;
 
                 // Destroy if application is running

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -176,15 +176,6 @@ namespace Mirror.Examples.Basic
             Destroy(playerUIObject);
         }
 
-        void OnDestroy()
-        {
-            Debug.Log("isClient " + isClient);
-            Debug.Log("isLocalPlayer " + isLocalPlayer);
-            Debug.Log("isServer " + isServer);
-            Debug.Log("NetworkClient.active " + NetworkClient.active);
-            Debug.Log("NetworkServer.active " + NetworkServer.active);
-        }
-
         #endregion
     }
 }

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -176,6 +176,15 @@ namespace Mirror.Examples.Basic
             Destroy(playerUIObject);
         }
 
+        void OnDestroy()
+        {
+            Debug.Log("isClient " + isClient);
+            Debug.Log("isLocalPlayer " + isLocalPlayer);
+            Debug.Log("isServer " + isServer);
+            Debug.Log("NetworkClient.active " + NetworkClient.active);
+            Debug.Log("NetworkServer.active " + NetworkServer.active);
+        }
+
         #endregion
     }
 }

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourTests.cs
@@ -855,6 +855,28 @@ namespace Mirror.Tests.NetworkBehaviours
             Assert.That(comp.onStopLocalPlayerCalled, Is.EqualTo(1));
         }
 
+        // test to prevent: https://github.com/MirrorNetworking/Mirror/issues/3832
+        class NetworkBehaviourOnDestroy : NetworkBehaviour
+        {
+            void OnDestroy()
+            {
+                Debug.LogWarning("OnDestroy called with isServer=" + isServer);
+                // on server, IsServer should still be false in OnDestroy.
+                Assert.That(isServer, Is.EqualTo(NetworkServer.active));
+            }
+        }
+        [Test]
+        public void NetworkDestroy_OnDestroyFlags()
+        {
+            NetworkServer.Listen(1);
+            ConnectClientBlockingAuthenticatedAndReady(out _);
+
+            CreateNetworked(out GameObject _, out NetworkIdentity identity, out NetworkBehaviourOnDestroy comp);
+            NetworkServer.Destroy(identity.gameObject);
+
+            // the NetworkBehaviourOnDestroy component has the asset to check isServer..
+        }
+
         [Test]
         public void AuthorityIsFalseVariations()
         {


### PR DESCRIPTION
explanation:
NS.Destroy() calls NS.Unspawn() which calls ResetState() which resets isServer
for prefabs, Destroy(go) -> OnDestroy() is called after, with isServer false due to the reset.
this change does not call ResetState() for prefabs anymore.

fixes the runtime test too:
![image](https://github.com/MirrorNetworking/Mirror/assets/16416509/0870a70e-83d2-49b8-ab90-971b008ec347)
