### PR TITLE
ClientSslHelper to wrap https in SSL

### DIFF
--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Client/StandAlone/ClientSslHelper.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWeb/Client/StandAlone/ClientSslHelper.cs
@@ -11,7 +11,7 @@ namespace Mirror.SimpleWeb
         internal bool TryCreateStream(Connection conn, Uri uri)
         {
             NetworkStream stream = conn.client.GetStream();
-            if (uri.Scheme != "wss")
+            if (uri.Scheme != "wss" && uri.Scheme != "https")
             {
                 conn.stream = stream;
                 return true;


### PR DESCRIPTION
Hi

We've found that when trying to connect to a Mirror server with a WebSocket transport using a https Uri, the client doesn't use SSL. Although it might be more technically correct to specify a wss Uri, if a connection is made with a https Uri then the intention would (surely) be to use SSL.

I've included a simple change which we've tested that seems to work fine if you wish to incorporate this.