### PR TITLE
fix(NetworkBehaviour): Skip OnValidate in Editor Play Mode

### DIFF
--- a/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyReliable.cs
+++ b/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyReliable.cs
@@ -11,6 +11,21 @@ namespace Mirror
         Rigidbody rb;
         bool wasKinematic;
 
+        protected override void OnValidate()
+        {
+            // Skip if Editor is in Play mode
+            if (Application.isPlaying) return;
+
+            base.OnValidate();
+
+            // we can't overwrite .target to be a Rigidbody.
+            // but we can ensure that .target has a Rigidbody, and use it.
+            if (target.GetComponent<Rigidbody>() == null)
+            {
+                Debug.LogWarning($"{name}'s NetworkRigidbody.target {target.name} is missing a Rigidbody", this);
+            }
+        }
+
         // cach Rigidbody and original isKinematic setting
         protected override void Awake()
         {
@@ -79,18 +94,6 @@ namespace Mirror
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
                 if (!owned) rb.isKinematic = true;
-            }
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-
-            // we can't overwrite .target to be a Rigidbody.
-            // but we can ensure that .target has a Rigidbody, and use it.
-            if (target.GetComponent<Rigidbody>() == null)
-            {
-                Debug.LogWarning($"{name}'s NetworkRigidbody.target {target.name} is missing a Rigidbody", this);
             }
         }
 

--- a/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyReliable2D.cs
+++ b/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyReliable2D.cs
@@ -11,6 +11,20 @@ namespace Mirror
         Rigidbody2D rb;
         bool wasKinematic;
 
+        protected override void OnValidate()
+        {
+            if (Application.isPlaying) return;
+
+            base.OnValidate();
+
+            // we can't overwrite .target to be a Rigidbody.
+            // but we can ensure that .target has a Rigidbody, and use it.
+            if (target.GetComponent<Rigidbody2D>() == null)
+            {
+                Debug.LogWarning($"{name}'s NetworkRigidbody2D.target {target.name} is missing a Rigidbody2D", this);
+            }
+        }
+
         // cach Rigidbody and original isKinematic setting
         protected override void Awake()
         {
@@ -79,18 +93,6 @@ namespace Mirror
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
                 if (!owned) rb.isKinematic = true;
-            }
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-
-            // we can't overwrite .target to be a Rigidbody.
-            // but we can ensure that .target has a Rigidbody, and use it.
-            if (target.GetComponent<Rigidbody2D>() == null)
-            {
-                Debug.LogWarning($"{name}'s NetworkRigidbody2D.target {target.name} is missing a Rigidbody2D", this);
             }
         }
 

--- a/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyUnreliable.cs
@@ -11,6 +11,21 @@ namespace Mirror
         Rigidbody rb;
         bool wasKinematic;
 
+        protected override void OnValidate()
+        {
+            // Skip if Editor is in Play mode
+            if (Application.isPlaying) return;
+
+            base.OnValidate();
+
+            // we can't overwrite .target to be a Rigidbody.
+            // but we can ensure that .target has a Rigidbody, and use it.
+            if (target.GetComponent<Rigidbody>() == null)
+            {
+                Debug.LogWarning($"{name}'s NetworkRigidbody.target {target.name} is missing a Rigidbody", this);
+            }
+        }
+
         // cach Rigidbody and original isKinematic setting
         protected override void Awake()
         {
@@ -79,18 +94,6 @@ namespace Mirror
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
                 if (!owned) rb.isKinematic = true;
-            }
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-
-            // we can't overwrite .target to be a Rigidbody.
-            // but we can ensure that .target has a Rigidbody, and use it.
-            if (target.GetComponent<Rigidbody>() == null)
-            {
-                Debug.LogWarning($"{name}'s NetworkRigidbody.target {target.name} is missing a Rigidbody", this);
             }
         }
 

--- a/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyUnreliable2D.cs
+++ b/Assets/Mirror/Components/NetworkRigidbody/NetworkRigidbodyUnreliable2D.cs
@@ -11,6 +11,21 @@ namespace Mirror
         Rigidbody2D rb;
         bool wasKinematic;
 
+        protected override void OnValidate()
+        {
+            // Skip if Editor is in Play mode
+            if (Application.isPlaying) return;
+
+            base.OnValidate();
+
+            // we can't overwrite .target to be a Rigidbody.
+            // but we can ensure that .target has a Rigidbody, and use it.
+            if (target.GetComponent<Rigidbody2D>() == null)
+            {
+                Debug.LogWarning($"{name}'s NetworkRigidbody2D.target {target.name} is missing a Rigidbody2D", this);
+            }
+        }
+
         // cach Rigidbody and original isKinematic setting
         protected override void Awake()
         {
@@ -79,18 +94,6 @@ namespace Mirror
                 // otherwise don't touch isKinematic.
                 // the authority owner might use it either way.
                 if (!owned) rb.isKinematic = true;
-            }
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-
-            // we can't overwrite .target to be a Rigidbody.
-            // but we can ensure that .target has a Rigidbody, and use it.
-            if (target.GetComponent<Rigidbody2D>() == null)
-            {
-                Debug.LogWarning($"{name}'s NetworkRigidbody2D.target {target.name} is missing a Rigidbody2D", this);
             }
         }
 

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -98,6 +98,17 @@ namespace Mirror
         public bool showOverlay;
         public Color overlayColor = new Color(0, 0, 0, 0.5f);
 
+        protected override void OnValidate()
+        {
+            // Skip if Editor is in Play mode
+            if (Application.isPlaying) return;
+
+            base.OnValidate();
+
+            // configure in awake
+            Configure();
+        }
+
         // initialization //////////////////////////////////////////////////////
         // forcec configuration of some settings
         protected virtual void Configure()
@@ -122,14 +133,6 @@ namespace Mirror
         {
             // sometimes OnValidate() doesn't run before launching a project.
             // need to guarantee configuration runs.
-            Configure();
-        }
-
-        protected override void OnValidate()
-        {
-            base.OnValidate();
-
-            // configure in awake
             Configure();
         }
 


### PR DESCRIPTION
OnValidate only runs in Editor, but can get invoked in PlayMode if user fiddles with the inspector or by other Unity activities.