### PR TITLE
breaking: remove NetworkBehaviour.syncInterval to prepare for tick aligned state sync / prediction

### DIFF
--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -89,8 +89,6 @@ namespace Mirror.Tests
             go = new GameObject();
             identity = go.AddComponent<NetworkIdentity>();
             component = go.AddComponent<T>();
-            // always set syncinterval = 0 for immediate testing
-            component.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -111,8 +109,6 @@ namespace Mirror.Tests
             // setup NetworkIdentity + NetworkBehaviour in child
             identity = parent.AddComponent<NetworkIdentity>();
             component = child.AddComponent<T>();
-            // always set syncinterval = 0 for immediate testing
-            component.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -130,9 +126,6 @@ namespace Mirror.Tests
             identity = go.AddComponent<NetworkIdentity>();
             componentA = go.AddComponent<T>();
             componentB = go.AddComponent<U>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -155,9 +148,6 @@ namespace Mirror.Tests
             identity = parent.AddComponent<NetworkIdentity>();
             componentA = child.AddComponent<T>();
             componentB = child.AddComponent<U>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -177,10 +167,6 @@ namespace Mirror.Tests
             componentA = go.AddComponent<T>();
             componentB = go.AddComponent<U>();
             componentC = go.AddComponent<V>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
-            componentC.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -205,10 +191,6 @@ namespace Mirror.Tests
             componentA = child.AddComponent<T>();
             componentB = child.AddComponent<U>();
             componentC = child.AddComponent<V>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
-            componentC.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourDirtyBitsTests.cs
@@ -94,10 +94,6 @@ namespace Mirror.Tests.NetworkBehaviours
             comp.list.Add(42);
             Assert.That(comp.IsDirty(), Is.True);
             comp.ClearAllDirtyBits();
-
-            // it should only be dirty after syncInterval elapsed
-            comp.syncInterval = float.MaxValue;
-            Assert.That(comp.IsDirty(), Is.False);
         }
 
         [Test]
@@ -106,8 +102,6 @@ namespace Mirror.Tests.NetworkBehaviours
             CreateNetworkedAndSpawn(out _, out _, out EmptyBehaviour emptyBehaviour,
                                     out _, out _, out _);
 
-            // set syncinterval so dirtybit works fine
-            emptyBehaviour.syncInterval = 0;
             Assert.That(emptyBehaviour.IsDirty(), Is.False);
 
             // set one syncvar dirty bit
@@ -125,8 +119,6 @@ namespace Mirror.Tests.NetworkBehaviours
             CreateNetworkedAndSpawn(out _, out _, out NetworkBehaviourWithSyncVarsAndCollections comp,
                                     out _, out _, out _);
 
-            // set syncinterval so dirtybit works fine
-            comp.syncInterval = 0;
             Assert.That(comp.IsDirty(), Is.False);
 
             // dirty the synclist
@@ -162,7 +154,6 @@ namespace Mirror.Tests.NetworkBehaviours
             Assert.That(monster.observers.Count, Is.EqualTo(0));
 
             // modify something in the monster so that dirty bit is set
-            monsterComp.syncInterval = 0;
             ++monsterComp.health;
             Assert.That(monsterComp.IsDirty(), Is.True);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
@@ -277,7 +277,6 @@ namespace Mirror.Tests.NetworkIdentities
             // pretend to be owned
             identity.isOwned = true;
             comp.syncMode = SyncMode.Owner;
-            comp.syncInterval = 0;
 
             // set to CLIENT with some unique values
             // and set connection to server to pretend we are the owner.
@@ -315,7 +314,6 @@ namespace Mirror.Tests.NetworkIdentities
             // pretend to be owned
             identity.isOwned = true;
             comp.syncMode = SyncMode.Observers;
-            comp.syncInterval = 0;
 
             // set to CLIENT with some unique values
             // and set connection to server to pretend we are the owner.

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
@@ -598,28 +598,16 @@ namespace Mirror.Tests.NetworkIdentities
                 out NetworkBehaviourMock compA,
                 out NetworkBehaviourMock compB);
 
-            // set syncintervals so one is always dirty, one is never dirty
-            compA.syncInterval = 0;
-            compB.syncInterval = Mathf.Infinity;
-
             // set components dirty bits
             compA.SetSyncVarDirtyBit(0x0001);
             compB.SetSyncVarDirtyBit(0x1001);
-            // dirty because interval reached and mask != 0
             Assert.That(compA.IsDirty(), Is.True);
-            // not dirty because syncinterval not reached
-            Assert.That(compB.IsDirty(), Is.False);
+            Assert.That(compB.IsDirty(), Is.True);
 
             // call identity.ClearAllComponentsDirtyBits
+            // dirty bits should be cleared now
             identity.ClearAllComponentsDirtyBits();
-            // should be cleared now
             Assert.That(compA.IsDirty(), Is.False);
-            // should be cleared now
-            Assert.That(compB.IsDirty(), Is.False);
-
-            // set compB syncinterval to 0 to check if the masks were cleared
-            // (if they weren't, then it would still be dirty now)
-            compB.syncInterval = 0;
             Assert.That(compB.IsDirty(), Is.False);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
@@ -40,8 +40,6 @@ namespace Mirror.Tests.NetworkTransformTests
 
             // create a networked object with NetworkTransform
             CreateNetworkedAndSpawn(out GameObject go, out NetworkIdentity _, out component, connectionToClient);
-            // sync immediately
-            component.syncInterval = 0;
             // remember transform for convenience
             transform = go.transform;
         }

--- a/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
@@ -102,9 +102,6 @@ namespace Mirror.Tests.SyncVars
         {
             CreateNetworked(out _, out _, out MockPlayer player);
 
-            // synchronize immediately
-            player.syncInterval = 0f;
-
             Assert.That(player.IsDirty(), Is.False, "First time object should not be dirty");
 
             MockPlayer.Guild myGuild = new MockPlayer.Guild
@@ -121,32 +118,6 @@ namespace Mirror.Tests.SyncVars
             // clearing the guild should set dirty bit too
             player.guild = default;
             Assert.That(player.IsDirty(), "Clearing struct should mark object as dirty");
-        }
-
-        [Test]
-        public void TestSyncIntervalAndClearAllComponents()
-        {
-            CreateNetworked(out _, out _, out MockPlayer player);
-            player.lastSyncTime = NetworkTime.localTime;
-            // synchronize immediately
-            player.syncInterval = 1f;
-
-            player.guild = new MockPlayer.Guild
-            {
-                name = "Back street boys"
-            };
-
-            Assert.That(player.IsDirty(), Is.False, "Sync interval not met, so not dirty yet");
-
-            // ClearAllComponents should clear dirty even if syncInterval not
-            // elapsed yet
-            player.netIdentity.ClearAllComponentsDirtyBits();
-
-            // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = NetworkTime.localTime - player.syncInterval;
-
-            // should be dirty now
-            Assert.That(player.IsDirty(), Is.False, "Sync interval met, should still not be dirty");
         }
 
         [Test]


### PR DESCRIPTION
_Credits to Ray for the explanations._

**We want to always sync state immediately for two reasons:**
1. Latency is the enemy. We want the games to feel tight, not delayed.
2. In order to support fast paced games like Shooters/Moba, we need to move towards tick aligned state sync.