### PR TITLE
breaking: remove NetworkBehaviour.syncInterval to prepare for tick aligned state sync / prediction

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -201,6 +201,7 @@ namespace Mirror
         void CheckSendRate()
         {
             double now = NetworkTime.localTime;
+            double syncInterval = 1f / NetworkManager.singleton.sendRate;
             if (SendMessagesAllowed && syncInterval >= 0 && now > nextSendTime)
             {
                 nextSendTime = now + syncInterval;

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -116,13 +116,6 @@ namespace Mirror
             // set target to self if none yet
             if (target == null) target = transform;
 
-            // time snapshot interpolation happens globally.
-            // value (transform) happens in here.
-            // both always need to be on the same send interval.
-            // force the setting to '0' in OnValidate to make it obvious that we
-            // actually use NetworkServer.sendInterval.
-            syncInterval = 0;
-
             // Unity doesn't support setting world scale.
             // OnValidate force disables syncScale in world mode.
             if (coordinateSpace == CoordinateSpace.World) syncScale = false;

--- a/Assets/Mirror/Components/PredictedRigidbody/PredictedRigidbody.cs
+++ b/Assets/Mirror/Components/PredictedRigidbody/PredictedRigidbody.cs
@@ -92,10 +92,6 @@ namespace Mirror
         [Tooltip("Teleport if we are further than 'multiplier x collider size' behind.")]
         public float teleportDistanceMultiplier = 10;
 
-        [Header("Bandwidth")]
-        [Tooltip("Reduce sends while velocity==0. Client's objects may slightly move due to gravity/physics, so we still want to send corrections occasionally even if an object is idle on the server the whole time.")]
-        public bool reduceSendsWhileIdle = true;
-
         // Rigidbody & Collider are moved out into a separate object.
         // this way the visual object can smoothly follow.
         protected GameObject physicsCopy;
@@ -395,23 +391,6 @@ namespace Mirror
 
         void UpdateServer()
         {
-            // bandwidth optimization while idle.
-            if (reduceSendsWhileIdle)
-            {
-                // while moving, always sync every frame for immediate corrections.
-                // while idle, only sync once per second.
-                //
-                // we still need to sync occasionally because objects on client
-                // may still slide or move slightly due to gravity, physics etc.
-                // and those still need to get corrected if not moving on server.
-                //
-                // TODO
-                // next round of optimizations: if client received nothing for 1s,
-                // force correct to last received state. then server doesn't need
-                // to send once per second anymore.
-                syncInterval = IsMoving() ? 0 : 1;
-            }
-
             // always set dirty to always serialize in next sync interval.
             SetDirty();
         }
@@ -948,11 +927,6 @@ namespace Mirror
 
             // force syncDirection to be ServerToClient
             syncDirection = SyncDirection.ServerToClient;
-
-            // state should be synced immediately for now.
-            // later when we have prediction fully dialed in,
-            // then we can maybe relax this a bit.
-            syncInterval = 0;
         }
 
         // helper function for Physics tests to check if a Rigidbody belongs to

--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -41,9 +41,9 @@ namespace Mirror
         // it makes sense to keep every component's syncInterval setting at '0' by default.
         // otherwise, the overlapping timers could introduce unexpected latency.
         // careful: default of '0.1' may
-        [Obsolete("NetworkBehaviour.syncInterval was removed. We are tightening up Mirror core in order to support fast paced games now too.")]
-        [Range(0, 2)]
-        [HideInInspector] public float syncInterval = 0;
+        // DEPRECATED 2024-07-11
+        [Obsolete("NetworkBehaviour.syncInterval was removed to better support fast paced games. All components now sync on '1 / NetworkManager sendRate'")]
+        public float syncInterval => 1f / NetworkManager.singleton.sendRate;
 
         /// <summary>True if this object is on the server and has been spawned.</summary>
         // This is different from NetworkServer.active, which is true if the

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -41,6 +41,9 @@ namespace Mirror
         [Tooltip("Server / Client send rate per second.\nUse 60-100Hz for fast paced games like Counter-Strike to minimize latency.\nUse around 30Hz for games like WoW to minimize computations.\nUse around 1-10Hz for slow paced games like EVE.")]
         [FormerlySerializedAs("serverTickRate")]
         public int sendRate = 60;
+        
+        // sendInterval := 1 / sendRate for convenience
+        public float sendInterval => 1f / sendRate;
 
         // Deprecated 2023-11-25
         // Using SerializeField and HideInInspector to self-correct for being

--- a/Assets/Mirror/Tests/Common/MirrorTest.cs
+++ b/Assets/Mirror/Tests/Common/MirrorTest.cs
@@ -89,8 +89,6 @@ namespace Mirror.Tests
             go = new GameObject();
             identity = go.AddComponent<NetworkIdentity>();
             component = go.AddComponent<T>();
-            // always set syncinterval = 0 for immediate testing
-            component.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -111,8 +109,6 @@ namespace Mirror.Tests
             // setup NetworkIdentity + NetworkBehaviour in child
             identity = parent.AddComponent<NetworkIdentity>();
             component = child.AddComponent<T>();
-            // always set syncinterval = 0 for immediate testing
-            component.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -130,9 +126,6 @@ namespace Mirror.Tests
             identity = go.AddComponent<NetworkIdentity>();
             componentA = go.AddComponent<T>();
             componentB = go.AddComponent<U>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -155,9 +148,6 @@ namespace Mirror.Tests
             identity = parent.AddComponent<NetworkIdentity>();
             componentA = child.AddComponent<T>();
             componentB = child.AddComponent<U>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -177,10 +167,6 @@ namespace Mirror.Tests
             componentA = go.AddComponent<T>();
             componentB = go.AddComponent<U>();
             componentC = go.AddComponent<V>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
-            componentC.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();
@@ -205,10 +191,6 @@ namespace Mirror.Tests
             componentA = child.AddComponent<T>();
             componentB = child.AddComponent<U>();
             componentC = child.AddComponent<V>();
-            // always set syncinterval = 0 for immediate testing
-            componentA.syncInterval = 0;
-            componentB.syncInterval = 0;
-            componentC.syncInterval = 0;
             // Awake is only called in play mode.
             // call manually for initialization.
             identity.Awake();

--- a/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourDirtyBitsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkBehaviour/NetworkBehaviourDirtyBitsTests.cs
@@ -94,10 +94,6 @@ namespace Mirror.Tests.NetworkBehaviours
             comp.list.Add(42);
             Assert.That(comp.IsDirty(), Is.True);
             comp.ClearAllDirtyBits();
-
-            // it should only be dirty after syncInterval elapsed
-            comp.syncInterval = float.MaxValue;
-            Assert.That(comp.IsDirty(), Is.False);
         }
 
         [Test]
@@ -106,8 +102,6 @@ namespace Mirror.Tests.NetworkBehaviours
             CreateNetworkedAndSpawn(out _, out _, out EmptyBehaviour emptyBehaviour,
                                     out _, out _, out _);
 
-            // set syncinterval so dirtybit works fine
-            emptyBehaviour.syncInterval = 0;
             Assert.That(emptyBehaviour.IsDirty(), Is.False);
 
             // set one syncvar dirty bit
@@ -125,8 +119,6 @@ namespace Mirror.Tests.NetworkBehaviours
             CreateNetworkedAndSpawn(out _, out _, out NetworkBehaviourWithSyncVarsAndCollections comp,
                                     out _, out _, out _);
 
-            // set syncinterval so dirtybit works fine
-            comp.syncInterval = 0;
             Assert.That(comp.IsDirty(), Is.False);
 
             // dirty the synclist
@@ -162,7 +154,6 @@ namespace Mirror.Tests.NetworkBehaviours
             Assert.That(monster.observers.Count, Is.EqualTo(0));
 
             // modify something in the monster so that dirty bit is set
-            monsterComp.syncInterval = 0;
             ++monsterComp.health;
             Assert.That(monsterComp.IsDirty(), Is.True);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
@@ -277,7 +277,6 @@ namespace Mirror.Tests.NetworkIdentities
             // pretend to be owned
             identity.isOwned = true;
             comp.syncMode = SyncMode.Owner;
-            comp.syncInterval = 0;
 
             // set to CLIENT with some unique values
             // and set connection to server to pretend we are the owner.
@@ -315,7 +314,6 @@ namespace Mirror.Tests.NetworkIdentities
             // pretend to be owned
             identity.isOwned = true;
             comp.syncMode = SyncMode.Observers;
-            comp.syncInterval = 0;
 
             // set to CLIENT with some unique values
             // and set connection to server to pretend we are the owner.

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentityTests.cs
@@ -598,28 +598,16 @@ namespace Mirror.Tests.NetworkIdentities
                 out NetworkBehaviourMock compA,
                 out NetworkBehaviourMock compB);
 
-            // set syncintervals so one is always dirty, one is never dirty
-            compA.syncInterval = 0;
-            compB.syncInterval = Mathf.Infinity;
-
             // set components dirty bits
             compA.SetSyncVarDirtyBit(0x0001);
             compB.SetSyncVarDirtyBit(0x1001);
-            // dirty because interval reached and mask != 0
             Assert.That(compA.IsDirty(), Is.True);
-            // not dirty because syncinterval not reached
-            Assert.That(compB.IsDirty(), Is.False);
+            Assert.That(compB.IsDirty(), Is.True);
 
             // call identity.ClearAllComponentsDirtyBits
+            // dirty bits should be cleared now
             identity.ClearAllComponentsDirtyBits();
-            // should be cleared now
             Assert.That(compA.IsDirty(), Is.False);
-            // should be cleared now
-            Assert.That(compB.IsDirty(), Is.False);
-
-            // set compB syncinterval to 0 to check if the masks were cleared
-            // (if they weren't, then it would still be dirty now)
-            compB.syncInterval = 0;
             Assert.That(compB.IsDirty(), Is.False);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkTransform/NetworkTransform2kTests.cs
@@ -40,8 +40,6 @@ namespace Mirror.Tests.NetworkTransformTests
 
             // create a networked object with NetworkTransform
             CreateNetworkedAndSpawn(out GameObject go, out NetworkIdentity _, out component, connectionToClient);
-            // sync immediately
-            component.syncInterval = 0;
             // remember transform for convenience
             transform = go.transform;
         }

--- a/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
@@ -102,9 +102,6 @@ namespace Mirror.Tests.SyncVars
         {
             CreateNetworked(out _, out _, out MockPlayer player);
 
-            // synchronize immediately
-            player.syncInterval = 0f;
-
             Assert.That(player.IsDirty(), Is.False, "First time object should not be dirty");
 
             MockPlayer.Guild myGuild = new MockPlayer.Guild
@@ -121,32 +118,6 @@ namespace Mirror.Tests.SyncVars
             // clearing the guild should set dirty bit too
             player.guild = default;
             Assert.That(player.IsDirty(), "Clearing struct should mark object as dirty");
-        }
-
-        [Test]
-        public void TestSyncIntervalAndClearAllComponents()
-        {
-            CreateNetworked(out _, out _, out MockPlayer player);
-            player.lastSyncTime = NetworkTime.localTime;
-            // synchronize immediately
-            player.syncInterval = 1f;
-
-            player.guild = new MockPlayer.Guild
-            {
-                name = "Back street boys"
-            };
-
-            Assert.That(player.IsDirty(), Is.False, "Sync interval not met, so not dirty yet");
-
-            // ClearAllComponents should clear dirty even if syncInterval not
-            // elapsed yet
-            player.netIdentity.ClearAllComponentsDirtyBits();
-
-            // set lastSyncTime far enough back to be ready for syncing
-            player.lastSyncTime = NetworkTime.localTime - player.syncInterval;
-
-            // should be dirty now
-            Assert.That(player.IsDirty(), Is.False, "Sync interval met, should still not be dirty");
         }
 
         [Test]


### PR DESCRIPTION
_Credits to Ray for the explanations._

**We want to always sync state immediately for two reasons:**
1. Latency is the enemy. We want the games to feel tight, not delayed.
2. In order to support fast paced games like Shooters/Moba, we need to move towards tick aligned state sync.