### PR TITLE
fix(SimpleWebTransport): increasing default handshake max size

### DIFF
--- a/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
+++ b/Assets/Mirror/Transports/SimpleWeb/SimpleWebTransport.cs
@@ -18,7 +18,7 @@ namespace Mirror.SimpleWeb
 
         [FormerlySerializedAs("handshakeMaxSize")]
         [Tooltip("Max size for http header send as handshake for websockets")]
-        public int maxHandshakeSize = 3000;
+        public int maxHandshakeSize = 16 * 1024;
 
         [FormerlySerializedAs("serverMaxMessagesPerTick")]
         [Tooltip("Caps the number of messages the server will process per tick. Allows LateUpdate to finish to let the reset of unity continue in case more messages arrive before they are processed")]


### PR DESCRIPTION
Some browsers will send handshake larger than 3k, setting default limit to 16k so user dont have to worry about changing it