### PR TITLE
Quake Style Networking WIP

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -17,6 +17,11 @@ namespace Mirror
     // that wouldn't be accurate. server's OnDeserialize can still validate
     // client data before applying. it's really about direction, not authority.
     public enum SyncDirection { ServerToClient, ClientToServer }
+    
+    // SyncMethod to choose between:
+    //   * Reliable: oldschool reliable sync every syncInterval. If nothing changes, nothing is sent.
+    //   * Unreliable: quake style unreliable state sync & delta compression, for fast paced games.
+    public enum SyncMethod { Reliable, Unreliable }
 
     /// <summary>Base class for networked components.</summary>
     // [RequireComponent(typeof(NetworkIdentity))] disabled to allow child NetworkBehaviours
@@ -24,6 +29,9 @@ namespace Mirror
     [HelpURL("https://mirror-networking.gitbook.io/docs/guides/networkbehaviour")]
     public abstract class NetworkBehaviour : MonoBehaviour
     {
+        [Tooltip("Choose between old school Reliable sync (every syncInterval if changed. no sync if unchanged.) vs. quake style Unreliable sync (sends the whole world state every tick, immediately) for fast paced games.\nReliable is recommended for most games.\nOnly choose Unreliable if you understand the tradeoffs.")]
+        [HideInInspector] public SyncMethod syncMethod = SyncMethod.Reliable;
+        
         /// <summary>Sync direction for OnSerialize. ServerToClient by default. ClientToServer for client authority.</summary>
         [Tooltip("Server Authority calls OnSerialize on the server and syncs it to clients.\n\nClient Authority calls OnSerialize on the owning client, syncs it to server, which then broadcasts it to all other clients.\n\nUse server authority for cheat safety.")]
         [HideInInspector] public SyncDirection syncDirection = SyncDirection.ServerToClient;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1160,7 +1160,7 @@ namespace Mirror
             {
                 using (NetworkReaderPooled payloadReader = NetworkReaderPool.Get(message.payload))
                 {
-                    identity.DeserializeClient(payloadReader, true);
+                    identity.DeserializeClientReliable(payloadReader, true);
                 }
             }
 
@@ -1388,7 +1388,7 @@ namespace Mirror
             if (spawned.TryGetValue(message.netId, out NetworkIdentity identity) && identity != null)
             {
                 using (NetworkReaderPooled reader = NetworkReaderPool.Get(message.payload))
-                    identity.DeserializeClient(reader, false);
+                    identity.DeserializeClientReliable(reader, false);
             }
             else Debug.LogWarning($"Did not find target for sync message for {message.netId}. Were all prefabs added to the NetworkManager's spawnable list?\nNote: this can be completely normal because UDP messages may arrive out of order, so this message might have arrived after a Destroy message.");
         }
@@ -1543,7 +1543,7 @@ namespace Mirror
                     {
                         // get serialization for this entity viewed by this connection
                         // (if anything was serialized this time)
-                        identity.SerializeClient(writer);
+                        identity.SerializeClientReliable(writer);
                         if (writer.Position > 0)
                         {
                             // send state update message

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -872,7 +872,7 @@ namespace Mirror
 
         // build dirty mask for client.
         // server always knows initialState, so we don't need it here.
-        ulong ClientDirtyMask()
+        ulong ClientDirtyMask(bool initialState)
         {
             ulong mask = 0;
 
@@ -892,7 +892,8 @@ namespace Mirror
                 {
                     // set the n-th bit if dirty
                     // shifting from small to large numbers is varint-efficient.
-                    if (component.IsDirty()) mask |= (1u << i);
+                    bool dirty = component.IsDirty();
+                    if (initialState || dirty) mask |= (1u << i);
                 }
             }
 
@@ -1012,7 +1013,8 @@ namespace Mirror
             // instead of writing a 1 byte index per component,
             // we limit components to 64 bits and write one ulong instead.
             // the ulong is also varint compressed for minimum bandwidth.
-            ulong dirtyMask = ClientDirtyMask();
+            // server always knows initialState, we never need to send it
+            ulong dirtyMask = ClientDirtyMask(false);
 
             // varint compresses the mask to 1 byte in most cases.
             // instead of writing an 8 byte ulong.

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1144,6 +1144,11 @@ namespace Mirror
             }
         }
 
+        // deserialize components from server on the client.
+        // unreliable state sync with initialState always true (full sync).
+        internal void DeserializeClientUnreliable(NetworkReader reader) =>
+            DeserializeClientReliable(reader, true);
+
         // get cached serialization for this tick (or serialize if none yet).
         // IMPORTANT: int tick avoids floating point inaccuracy over days/weeks.
         // calls SerializeServer, so this function is to be called on server.

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -912,7 +912,9 @@ namespace Mirror
         // check ownerWritten/observersWritten to know if anything was written
         // We pass dirtyComponentsMask into this function so that we can check
         // if any Components are dirty before creating writers
-        internal void SerializeServer(bool initialState, NetworkWriter ownerWriter, NetworkWriter observersWriter)
+        // reliable state sync with initialState true, and then false for delta.
+        // this is sent over the Transport's reliable channel.
+        internal void SerializeServerReliable(bool initialState, NetworkWriter ownerWriter, NetworkWriter observersWriter)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -985,7 +987,9 @@ namespace Mirror
         }
 
         // serialize components into writer on the client.
-        internal void SerializeClient(NetworkWriter writer)
+        // reliable state sync with initialState true, and then false for delta.
+        // this is sent over the Transport's reliable channel.
+        internal void SerializeClientReliable(NetworkWriter writer)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -1043,7 +1047,7 @@ namespace Mirror
 
         // deserialize components from the client on the server.
         // there's no 'initialState'. server always knows the initial state.
-        internal bool DeserializeServer(NetworkReader reader)
+        internal bool DeserializeServerReliable(NetworkReader reader)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -1086,7 +1090,9 @@ namespace Mirror
         }
 
         // deserialize components from server on the client.
-        internal void DeserializeClient(NetworkReader reader, bool initialState)
+        // reliable state sync with initialState true, and then false for delta.
+        // this is sent over the Transport's reliable channel.
+        internal void DeserializeClientReliable(NetworkReader reader, bool initialState)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -1130,9 +1136,9 @@ namespace Mirror
                 lastSerialization.observersWriter.Position = 0;
 
                 // serialize
-                SerializeServer(false,
-                                lastSerialization.ownerWriter,
-                                lastSerialization.observersWriter);
+                SerializeServerReliable(false,
+                                        lastSerialization.ownerWriter,
+                                        lastSerialization.observersWriter);
 
                 // set tick
                 lastSerialization.tick = tick;

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1067,8 +1067,7 @@ namespace Mirror
             SerializeClient(true, writer);
 
         // deserialize components from the client on the server.
-        // there's no 'initialState'. server always knows the initial state.
-        internal bool DeserializeServerReliable(NetworkReader reader)
+        internal bool DeserializeServer(bool initialState, NetworkReader reader)
         {
             // ensure NetworkBehaviours are valid before usage
             ValidateComponents();
@@ -1092,7 +1091,7 @@ namespace Mirror
                         // deserialize this component
                         // server always knows the initial state (initial=false)
                         // disconnect if failed, to prevent exploits etc.
-                        if (!comp.Deserialize(reader, false)) return false;
+                        if (!comp.Deserialize(reader, initialState)) return false;
 
                         // server received state from the owner client.
                         // set dirty so it's broadcast to other clients too.
@@ -1109,6 +1108,16 @@ namespace Mirror
             // successfully deserialized everything
             return true;
         }
+
+        // deserialize components from the client on the server.
+        // there's no 'initialState'. server always knows the initial state.
+        internal bool DeserializeServerReliable(NetworkReader reader) =>
+            DeserializeServer(false, reader);
+
+        // deserialize components from the client on the server.
+        // unreliable state sync with initialState always true (full sync).
+        internal bool DeserializeServerUnreliable(NetworkReader reader) =>
+            DeserializeServer(true, reader);
 
         // deserialize components from server on the client.
         // reliable state sync with initialState true, and then false for delta.

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -986,6 +986,16 @@ namespace Mirror
             }
         }
 
+        // serialize components into writer on the server.
+        // check ownerWritten/observersWritten to know if anything was written
+        // We pass dirtyComponentsMask into this function so that we can check
+        // if any Components are dirty before creating writers
+        // unreliable state sync with initialState always true (full sync).
+        // this is sent over the Transport's unreliable channel.
+        internal void SerializeServerUnreliable(NetworkWriter ownerWriter, NetworkWriter observersWriter) =>
+            // unreliable simply always serializes with initialState=true.
+            SerializeServerReliable(true, ownerWriter, observersWriter);
+
         // serialize components into writer on the client.
         // reliable state sync with initialState true, and then false for delta.
         // this is sent over the Transport's reliable channel.

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -384,7 +384,7 @@ namespace Mirror
                     {
                         // DeserializeServer checks permissions internally.
                         // failure to deserialize disconnects to prevent exploits.
-                        if (!identity.DeserializeServer(reader))
+                        if (!identity.DeserializeServerReliable(reader))
                         {
                             if (exceptionsDisconnect)
                             {
@@ -1368,7 +1368,7 @@ namespace Mirror
 
             // serialize all components with initialState = true
             // (can be null if has none)
-            identity.SerializeServer(true, ownerWriter, observersWriter);
+            identity.SerializeServerReliable(true, ownerWriter, observersWriter);
 
             // convert to ArraySegment to avoid reader allocations
             // if nothing was written, .ToArraySegment returns an empty segment.

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -86,6 +86,10 @@ namespace Mirror
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Sync Settings", EditorStyles.boldLabel);
 
+            // sync method
+            SerializedProperty syncMethod = serializedObject.FindProperty("syncMethod");
+            EditorGUILayout.PropertyField(syncMethod);
+            
             // sync direction
             SerializedProperty syncDirection = serializedObject.FindProperty("syncDirection");
             EditorGUILayout.PropertyField(syncDirection);
@@ -94,8 +98,9 @@ namespace Mirror
             if (syncDirection.enumValueIndex == (int)SyncDirection.ServerToClient)
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
 
-            // sync interval
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("syncInterval"));
+            // sync interval: only shown for reliable sync
+            if (syncMethod.enumValueIndex == (int)SyncMethod.Reliable)
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("syncInterval"));
 
             // apply
             serializedObject.ApplyModifiedProperties();

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -90,7 +90,7 @@ namespace Mirror
             SerializedProperty syncDirection = serializedObject.FindProperty("syncDirection");
             EditorGUILayout.PropertyField(syncDirection);
 
-            // sync mdoe: only show for ServerToClient components
+            // sync mode: only show for ServerToClient components
             if (syncDirection.enumValueIndex == (int)SyncDirection.ServerToClient)
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentity/NetworkIdentitySerializationTests.cs
@@ -50,11 +50,11 @@ namespace Mirror.Tests.NetworkIdentities
             serverObserversComp.value = 42;
 
             // serialize server object
-            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServerReliable(true, ownerWriter, observersWriter);
 
             // deserialize client object with OWNER payload
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
             Assert.That(clientOwnerComp.value, Is.EqualTo("42"));
             Assert.That(clientObserversComp.value, Is.EqualTo(42));
 
@@ -64,7 +64,7 @@ namespace Mirror.Tests.NetworkIdentities
 
             // deserialize client object with OBSERVERS payload
             reader = new NetworkReader(observersWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
             Assert.That(clientOwnerComp.value, Is.EqualTo(null)); // owner mode shouldn't be in data
             Assert.That(clientObserversComp.value, Is.EqualTo(42)); // observers mode should be in data
         }
@@ -96,13 +96,13 @@ namespace Mirror.Tests.NetworkIdentities
             // serialize server object
             // should work even if compExc throws an exception.
             // error log because of the exception is expected.
-            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServerReliable(true, ownerWriter, observersWriter);
 
             // deserialize client object with OWNER payload
             // should work even if compExc throws an exception
             // error log because of the exception is expected
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
             Assert.That(clientComp2.value, Is.EqualTo("42"));
 
             // reset component values
@@ -112,7 +112,7 @@ namespace Mirror.Tests.NetworkIdentities
             // should work even if compExc throws an exception
             // error log because of the exception is expected
             reader = new NetworkReader(observersWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
             Assert.That(clientComp2.value, Is.EqualTo(null)); // owner mode should be in data
 
             // restore error checks
@@ -187,13 +187,13 @@ namespace Mirror.Tests.NetworkIdentities
             serverComp.value = "42";
 
             // serialize server object
-            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServerReliable(true, ownerWriter, observersWriter);
 
             // deserialize on client
             // ignore warning log because of serialization mismatch
             LogAssert.ignoreFailingMessages = true;
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
             LogAssert.ignoreFailingMessages = false;
 
             // the mismatch component will fail, but the one before and after
@@ -219,7 +219,7 @@ namespace Mirror.Tests.NetworkIdentities
             // serialize server object.
             // 'initial' would write everything.
             // instead, try 'not initial' with 0 dirty bits
-            serverIdentity.SerializeServer(false, ownerWriter, observersWriter);
+            serverIdentity.SerializeServerReliable(false, ownerWriter, observersWriter);
             Assert.That(ownerWriter.Position, Is.EqualTo(0));
             Assert.That(observersWriter.Position, Is.EqualTo(0));
         }
@@ -236,7 +236,7 @@ namespace Mirror.Tests.NetworkIdentities
             // clientComp.value = "42";
 
             // serialize client object
-            serverIdentity.SerializeClient(ownerWriter);
+            serverIdentity.SerializeClientReliable(ownerWriter);
             Assert.That(ownerWriter.Position, Is.EqualTo(0));
         }
 
@@ -260,7 +260,7 @@ namespace Mirror.Tests.NetworkIdentities
             comp2.value = "67890";
 
             // serialize all
-            identity.SerializeClient(ownerWriter);
+            identity.SerializeClientReliable(ownerWriter);
 
             // shouldn't sync anything. because even though it's ClientToServer,
             // we don't own this one so we shouldn't serialize & sync it.
@@ -285,7 +285,7 @@ namespace Mirror.Tests.NetworkIdentities
             comp.SetValue(11); // modify with helper function to avoid #3525
 
             // initial: should still write for owner
-            identity.SerializeServer(true, ownerWriter, observersWriter);
+            identity.SerializeServerReliable(true, ownerWriter, observersWriter);
             Debug.Log("initial ownerWriter: " + ownerWriter);
             Debug.Log("initial observerWriter: " + observersWriter);
             Assert.That(ownerWriter.Position, Is.GreaterThan(0));
@@ -295,7 +295,7 @@ namespace Mirror.Tests.NetworkIdentities
             comp.SetValue(22); // modify with helper function to avoid #3525
             ownerWriter.Position = 0;
             observersWriter.Position = 0;
-            identity.SerializeServer(false, ownerWriter, observersWriter);
+            identity.SerializeServerReliable(false, ownerWriter, observersWriter);
             Debug.Log("delta ownerWriter: " + ownerWriter);
             Debug.Log("delta observersWriter: " + observersWriter);
             Assert.That(ownerWriter.Position, Is.EqualTo(0));
@@ -323,7 +323,7 @@ namespace Mirror.Tests.NetworkIdentities
             comp.SetValue(11); // modify with helper function to avoid #3525
 
             // initial: should write something for owner and observers
-            identity.SerializeServer(true, ownerWriter, observersWriter);
+            identity.SerializeServerReliable(true, ownerWriter, observersWriter);
             Debug.Log("initial ownerWriter: " + ownerWriter);
             Debug.Log("initial observerWriter: " + observersWriter);
             Assert.That(ownerWriter.Position, Is.GreaterThan(0));
@@ -333,7 +333,7 @@ namespace Mirror.Tests.NetworkIdentities
             comp.SetValue(22); // modify with helper function to avoid #3525
             ownerWriter.Position = 0;
             observersWriter.Position = 0;
-            identity.SerializeServer(false, ownerWriter, observersWriter);
+            identity.SerializeServerReliable(false, ownerWriter, observersWriter);
             Debug.Log("delta ownerWriter: " + ownerWriter);
             Debug.Log("delta observersWriter: " + observersWriter);
             Assert.That(ownerWriter.Position, Is.EqualTo(0));

--- a/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncVars/SyncVarAttributeTest.cs
@@ -404,7 +404,7 @@ namespace Mirror.Tests.SyncVars
             NetworkWriter ownerWriter = new NetworkWriter();
             // not really used in this Test
             NetworkWriter observersWriter = new NetworkWriter();
-            serverIdentity.SerializeServer(true, ownerWriter, observersWriter);
+            serverIdentity.SerializeServerReliable(true, ownerWriter, observersWriter);
 
             // set up a "client" object
             CreateNetworked(out _, out NetworkIdentity clientIdentity, out SyncVarAbstractNetworkBehaviour clientBehaviour);
@@ -412,7 +412,7 @@ namespace Mirror.Tests.SyncVars
 
             // apply all the data from the server object
             NetworkReader reader = new NetworkReader(ownerWriter.ToArray());
-            clientIdentity.DeserializeClient(reader, true);
+            clientIdentity.DeserializeClientReliable(reader, true);
 
             // check that the syncvars got updated
             Debug.Log($"{clientBehaviour.monster1} and {serverBehaviour.monster1}");


### PR DESCRIPTION
Work towards better serving fast paced games like shooters / moba.
Implement Quake style networking, without breaking everyone's project.

# 1. SyncMethod
**`NetworkBehaviour.syncMethod {Traditional, FastPaced}`**
Keep all existing projects on **Traditonal**, which is reliable state sync.
Offer **FastPaced** options for FPS/Mobas/etc. 

![image](https://github.com/MirrorNetworking/Mirror/assets/16416509/ffa8a2d9-86b8-438f-bdf3-5eed3ad832b3)

# TODO
- OnSerializeUnreliable (one MTU sized message per component for now)
- Switch NT-Unreliable to use OnSerializeUnreliable
- Snapshot Interpolation buffering built in for FastPaced mode
- Fragmentation to support > MTU sized messages
- Tick alignment: sync all FastPaced components at the same time
- syncDirection: always ServerToClient for FastPaced method?
- Client buffers WorldStates
- Client applies snapshot interpolation to the whole world state
- Client acks
- Delta compression against last acked to minimize bandwidth (DOTSNET spawned/updated/unspawned method)