### PR TITLE
perf: NetworkReader/Writer: read/write collection size headers as VarInt (Benchmark: 150 -> 120 KB/s)

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -100,7 +100,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint count = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint count = (uint)Compression.DecompressVarUInt(reader);
+            // uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? null : reader.ReadBytes(checked((int)(count - 1u)));
         }
@@ -111,7 +114,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint count = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint count = (uint)Compression.DecompressVarUInt(reader);
+            // uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
         }
@@ -269,7 +275,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            // uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 
@@ -301,7 +310,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            //uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 
@@ -319,7 +331,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            //uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -99,10 +99,14 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (buffer == null)
             {
-                writer.WriteUInt(0u);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0u);
                 return;
             }
-            writer.WriteUInt(checked((uint)count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)count) + 1u);
+            // writer.WriteUInt(checked((uint)count) + 1u);
             writer.WriteBytes(buffer, offset, count);
         }
 
@@ -124,7 +128,9 @@ namespace Mirror
             // - ReadArray
             // in which case ReadArray needs null support. both need to be compatible.
             int count = segment.Count;
-            writer.WriteUInt(checked((uint)count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)count) + 1u);
+            // writer.WriteUInt(checked((uint)count) + 1u);
             for (int i = 0; i < count; i++)
             {
                 writer.Write(segment.Array[segment.Offset + i]);
@@ -328,7 +334,9 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (list is null)
             {
-                writer.WriteUInt(0);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0);
                 return;
             }
 
@@ -336,7 +344,9 @@ namespace Mirror
             if (list.Count > NetworkReader.AllocationLimit)
                 throw new IndexOutOfRangeException($"NetworkWriter.WriteList - List<{typeof(T)}> too big: {list.Count} elements. Limit: {NetworkReader.AllocationLimit}");
 
-            writer.WriteUInt(checked((uint)list.Count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)list.Count) + 1u);
+            // writer.WriteUInt(checked((uint)list.Count) + 1u);
             for (int i = 0; i < list.Count; i++)
                 writer.Write(list[i]);
         }
@@ -346,22 +356,27 @@ namespace Mirror
         // fully serialize for NetworkMessages etc.
         // note that Weaver/Writers/GenerateWriter() handles this manually.
         // TODO writer not found. need to adjust weaver first. see tests.
-        /*
-        public static void WriteHashSet<T>(this NetworkWriter writer, HashSet<T> hashSet)
-        {
-            // we offset count by '1' to easily support null without writing another byte.
-            // encoding null as '0' instead of '-1' also allows for better compression
-            // (ushort vs. short / varuint vs. varint) etc.
-            if (hashSet is null)
-            {
-                writer.WriteUInt(0);
-                return;
-            }
-            writer.WriteUInt(checked((uint)hashSet.Count) + 1u);
-            foreach (T item in hashSet)
-                writer.Write(item);
-        }
-        */
+        // /*
+        // public static void WriteHashSet<T>(this NetworkWriter writer, HashSet<T> hashSet)
+        // {
+        //     // we offset count by '1' to easily support null without writing another byte.
+        //     // encoding null as '0' instead of '-1' also allows for better compression
+        //     // (ushort vs. short / varuint vs. varint) etc.
+        //     if (hashSet is null)
+        //     {
+        //         // most sizes are small, write size as VarUInt!
+        //         Compression.CompressVarUInt(writer, 0u);
+        //         //writer.WriteUInt(0);
+        //         return;
+        //     }
+        //
+        //     // most sizes are small, write size as VarUInt!
+        //     Compression.CompressVarUInt(writer, checked((uint)hashSet.Count) + 1u);
+        //     //writer.WriteUInt(checked((uint)hashSet.Count) + 1u);
+        //     foreach (T item in hashSet)
+        //         writer.Write(item);
+        // }
+        // */
 
         public static void WriteArray<T>(this NetworkWriter writer, T[] array)
         {
@@ -370,7 +385,9 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (array is null)
             {
-                writer.WriteUInt(0);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0);
                 return;
             }
 
@@ -378,7 +395,9 @@ namespace Mirror
             if (array.Length > NetworkReader.AllocationLimit)
                 throw new IndexOutOfRangeException($"NetworkWriter.WriteArray - Array<{typeof(T)}> too big: {array.Length} elements. Limit: {NetworkReader.AllocationLimit}");
 
-            writer.WriteUInt(checked((uint)array.Length) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)array.Length) + 1u);
+            // writer.WriteUInt(checked((uint)array.Length) + 1u);
             for (int i = 0; i < array.Length; i++)
                 writer.Write(array[i]);
         }

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -17,12 +17,13 @@ namespace Mirror.Tests.NetworkServers
     {
         // weaver serializes byte[] wit WriteBytesAndSize
         public byte[] payload;
-        // so payload := size - 4
+        // so payload := size - header
+        //   where header is VarUInt compression(size)
         // then the message is exactly maxed size.
         //
         // NOTE: we have a LargerMaxMessageSize test which guarantees that
         //       variablesized + 1 is exactly transport.max + 1
-        public VariableSizedMessage(int size) => payload = new byte[size - 4];
+        public VariableSizedMessage(int size) => payload = new byte[size - Compression.VarUIntSize((uint)size)];
     }
 
     public class CommandTestNetworkBehaviour : NetworkBehaviour


### PR DESCRIPTION
# FIRST REAL WORLD TESTS:
- 2% worse CPU perf
- 15% better bandwidth

pending more tests to see if this is worth it.

# Explanation
all ArraySegment/List/Collection .Counts are now encoded as VarInt instead of full 4 bytes int.
this will reduce bandwidth for the majority of collections down from 4 to 1 (or 2) bytes.

Examples/Benchmark:
- before: 150 KB/s
- after: 120 KB/s

![image](https://github.com/user-attachments/assets/063872b1-ea78-476d-85dc-86df8c1b684d)
