### PR TITLE
NetworkReader/Writer: all types of collections are now encoded via count-offsetting (null=0, []=1) for consistency and to prepare for VarUInt compression (this way we won't need zig zag VarInt)

### DIFF
--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -97,8 +97,9 @@ namespace Mirror
         /// <exception cref="T:OverflowException">if count is invalid</exception>
         public static byte[] ReadBytesAndSize(this NetworkReader reader)
         {
-            // count = 0 means the array was null
-            // otherwise count -1 is the length of the array
+            // we offset count by '1' to easily support null without writing another byte.
+            // encoding null as '0' instead of '-1' also allows for better compression
+            // (ushort vs. short / varuint vs. varint) etc.
             uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? null : reader.ReadBytes(checked((int)(count - 1u)));
@@ -107,8 +108,9 @@ namespace Mirror
         /// <exception cref="T:OverflowException">if count is invalid</exception>
         public static ArraySegment<byte> ReadArraySegmentAndSize(this NetworkReader reader)
         {
-            // count = 0 means the array was null
-            // otherwise count - 1 is the length of the array
+            // we offset count by '1' to easily support null without writing another byte.
+            // encoding null as '0' instead of '-1' also allows for better compression
+            // (ushort vs. short / varuint vs. varint) etc.
             uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -51,10 +51,9 @@ namespace Mirror
 
         public static void WriteString(this NetworkWriter writer, string value)
         {
-            // write 0 for null support, increment real size by 1
-            // (note: original HLAPI would write "" for null strings, but if a
-            //        string is null on the server then it should also be null
-            //        on the client)
+            // we offset count by '1' to easily support null without writing another byte.
+            // encoding null as '0' instead of '-1' also allows for better compression
+            // (ushort vs. short / varuint vs. varint) etc.
             if (value == null)
             {
                 writer.WriteUShort(0);
@@ -94,9 +93,10 @@ namespace Mirror
         // (like an inventory with different items etc.)
         public static void WriteBytesAndSize(this NetworkWriter writer, byte[] buffer, int offset, int count)
         {
-            // null is supported because [SyncVar]s might be structs with null byte[] arrays
-            // write 0 for null array, increment normal size by 1 to save bandwidth
-            // (using size=-1 for null would limit max size to 32kb instead of 64kb)
+            // null is supported because [SyncVar]s might be structs with null byte[] arrays.
+            // we offset count by '1' to easily support null without writing another byte.
+            // encoding null as '0' instead of '-1' also allows for better compression
+            // (ushort vs. short / varuint vs. varint) etc.
             if (buffer == null)
             {
                 writer.WriteUInt(0u);

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
@@ -1404,7 +1404,8 @@ namespace Mirror.Tests.NetworkReaderWriter
 
             void WriteBadArray()
             {
-                writer.WriteInt(badLength);
+                // Reader/Writer encode null as count=0 and [] as count=1 (+1 offset)
+                writer.WriteUInt((uint)(badLength+1));
                 int[] array = new int[testArraySize] { 1, 2, 3, 4 };
                 for (int i = 0; i < array.Length; i++)
                     writer.Write(array[i]);


### PR DESCRIPTION
Internal cleanup. Doesn't optimize any bandwidth yet.


Array null count is written as 0.
Array [] count is written as 1.
Array[n] count is written as 2.
Array [n,m] count is written as 3.

List null count was written as -1 (int instead of uint).
This PR changes it so that List null count is written as 0, just like Array.

This has two advantages:
- Count as unsigned allows for uint instead of int / ushort instead of short, etc.
- Prepares for VarInt compression so we don't need to write zigzag (for the -1)