### PR TITLE
perf: Weaver automatically uses VarInt compression for all integers in [SyncVar]/[Command]/[Rpc]/SyncList/NetworkMessage/etc.

### DIFF
--- a/Assets/Mirror/Core/Attributes.cs
+++ b/Assets/Mirror/Core/Attributes.cs
@@ -92,4 +92,10 @@ namespace Mirror
     /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public class ReadOnlyAttribute : PropertyAttribute {}
+
+    /// <summary>
+    /// When defining multiple Readers/Writers for the same type, indicate which one Weaver must use.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class WeaverPriorityAttribute : Attribute {}
 }

--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -100,7 +100,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint count = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint count = (uint)Compression.DecompressVarUInt(reader);
+            // uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? null : reader.ReadBytes(checked((int)(count - 1u)));
         }
@@ -111,7 +114,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint count = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint count = (uint)Compression.DecompressVarUInt(reader);
+            // uint count = reader.ReadUInt();
             // Use checked() to force it to throw OverflowException if data is invalid
             return count == 0 ? default : reader.ReadBytesSegment(checked((int)(count - 1u)));
         }
@@ -269,7 +275,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            // uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 
@@ -301,7 +310,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            //uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 
@@ -319,7 +331,10 @@ namespace Mirror
             // we offset count by '1' to easily support null without writing another byte.
             // encoding null as '0' instead of '-1' also allows for better compression
             // (ushort vs. short / varuint vs. varint) etc.
-            uint length = reader.ReadUInt();
+
+            // most sizes are small, read size as VarUInt!
+            uint length = (uint)Compression.DecompressVarUInt(reader);
+            //uint length = reader.ReadUInt();
             if (length == 0) return null;
             length -= 1;
 

--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -46,13 +46,12 @@ namespace Mirror
         public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBlittableNullable<ulong>();
 
         // ReadInt/UInt/Long/ULong writes full bytes by default.
-        // define additional "_Compressed" versions that Weaver will automatically prefer.
-        // using VarInt compression for all users types gives significant bandwidth reductions.
-        // 99% of the time [SyncVar] ints are small values, which makes this worth it.
-        public static int ReadInt_Compressed(this NetworkReader reader) => (int)Compression.DecompressVarInt(reader);
-        public static uint ReadUInt_Compressed(this NetworkReader reader) => (uint)Compression.DecompressVarUInt(reader);
-        public static long ReadLong_Compressed(this NetworkReader reader) => Compression.DecompressVarInt(reader);
-        public static ulong ReadULong_Compressed(this NetworkReader reader) => Compression.DecompressVarUInt(reader);
+        // define additional "VarInt" versions that Weaver will automatically prefer.
+        // 99% of the time [SyncVar] ints are small values, which makes this very much worth it.
+        [WeaverPriority] public static int ReadVarInt(this NetworkReader reader) => (int)Compression.DecompressVarInt(reader);
+        [WeaverPriority] public static uint ReadVarUInt(this NetworkReader reader) => (uint)Compression.DecompressVarUInt(reader);
+        [WeaverPriority] public static long ReadVarLong(this NetworkReader reader) => Compression.DecompressVarInt(reader);
+        [WeaverPriority] public static ulong ReadVarULong(this NetworkReader reader) => Compression.DecompressVarUInt(reader);
 
         public static float ReadFloat(this NetworkReader reader) => reader.ReadBlittable<float>();
         public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBlittableNullable<float>();

--- a/Assets/Mirror/Core/NetworkReaderExtensions.cs
+++ b/Assets/Mirror/Core/NetworkReaderExtensions.cs
@@ -45,6 +45,15 @@ namespace Mirror
         public static ulong ReadULong(this NetworkReader reader) => reader.ReadBlittable<ulong>();
         public static ulong? ReadULongNullable(this NetworkReader reader) => reader.ReadBlittableNullable<ulong>();
 
+        // ReadInt/UInt/Long/ULong writes full bytes by default.
+        // define additional "_Compressed" versions that Weaver will automatically prefer.
+        // using VarInt compression for all users types gives significant bandwidth reductions.
+        // 99% of the time [SyncVar] ints are small values, which makes this worth it.
+        public static int ReadInt_Compressed(this NetworkReader reader) => (int)Compression.DecompressVarInt(reader);
+        public static uint ReadUInt_Compressed(this NetworkReader reader) => (uint)Compression.DecompressVarUInt(reader);
+        public static long ReadLong_Compressed(this NetworkReader reader) => Compression.DecompressVarInt(reader);
+        public static ulong ReadULong_Compressed(this NetworkReader reader) => Compression.DecompressVarUInt(reader);
+
         public static float ReadFloat(this NetworkReader reader) => reader.ReadBlittable<float>();
         public static float? ReadFloatNullable(this NetworkReader reader) => reader.ReadBlittableNullable<float>();
 

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -99,10 +99,14 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (buffer == null)
             {
-                writer.WriteUInt(0u);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0u);
                 return;
             }
-            writer.WriteUInt(checked((uint)count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)count) + 1u);
+            // writer.WriteUInt(checked((uint)count) + 1u);
             writer.WriteBytes(buffer, offset, count);
         }
 
@@ -124,7 +128,9 @@ namespace Mirror
             // - ReadArray
             // in which case ReadArray needs null support. both need to be compatible.
             int count = segment.Count;
-            writer.WriteUInt(checked((uint)count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)count) + 1u);
+            // writer.WriteUInt(checked((uint)count) + 1u);
             for (int i = 0; i < count; i++)
             {
                 writer.Write(segment.Array[segment.Offset + i]);
@@ -328,7 +334,9 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (list is null)
             {
-                writer.WriteUInt(0);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0);
                 return;
             }
 
@@ -336,7 +344,9 @@ namespace Mirror
             if (list.Count > NetworkReader.AllocationLimit)
                 throw new IndexOutOfRangeException($"NetworkWriter.WriteList - List<{typeof(T)}> too big: {list.Count} elements. Limit: {NetworkReader.AllocationLimit}");
 
-            writer.WriteUInt(checked((uint)list.Count) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)list.Count) + 1u);
+            // writer.WriteUInt(checked((uint)list.Count) + 1u);
             for (int i = 0; i < list.Count; i++)
                 writer.Write(list[i]);
         }
@@ -346,22 +356,27 @@ namespace Mirror
         // fully serialize for NetworkMessages etc.
         // note that Weaver/Writers/GenerateWriter() handles this manually.
         // TODO writer not found. need to adjust weaver first. see tests.
-        /*
-        public static void WriteHashSet<T>(this NetworkWriter writer, HashSet<T> hashSet)
-        {
-            // we offset count by '1' to easily support null without writing another byte.
-            // encoding null as '0' instead of '-1' also allows for better compression
-            // (ushort vs. short / varuint vs. varint) etc.
-            if (hashSet is null)
-            {
-                writer.WriteUInt(0);
-                return;
-            }
-            writer.WriteUInt(checked((uint)hashSet.Count) + 1u);
-            foreach (T item in hashSet)
-                writer.Write(item);
-        }
-        */
+        // /*
+        // public static void WriteHashSet<T>(this NetworkWriter writer, HashSet<T> hashSet)
+        // {
+        //     // we offset count by '1' to easily support null without writing another byte.
+        //     // encoding null as '0' instead of '-1' also allows for better compression
+        //     // (ushort vs. short / varuint vs. varint) etc.
+        //     if (hashSet is null)
+        //     {
+        //         // most sizes are small, write size as VarUInt!
+        //         Compression.CompressVarUInt(writer, 0u);
+        //         //writer.WriteUInt(0);
+        //         return;
+        //     }
+        //
+        //     // most sizes are small, write size as VarUInt!
+        //     Compression.CompressVarUInt(writer, checked((uint)hashSet.Count) + 1u);
+        //     //writer.WriteUInt(checked((uint)hashSet.Count) + 1u);
+        //     foreach (T item in hashSet)
+        //         writer.Write(item);
+        // }
+        // */
 
         public static void WriteArray<T>(this NetworkWriter writer, T[] array)
         {
@@ -370,7 +385,9 @@ namespace Mirror
             // (ushort vs. short / varuint vs. varint) etc.
             if (array is null)
             {
-                writer.WriteUInt(0);
+                // most sizes are small, write size as VarUInt!
+                Compression.CompressVarUInt(writer, 0u);
+                // writer.WriteUInt(0);
                 return;
             }
 
@@ -378,7 +395,9 @@ namespace Mirror
             if (array.Length > NetworkReader.AllocationLimit)
                 throw new IndexOutOfRangeException($"NetworkWriter.WriteArray - Array<{typeof(T)}> too big: {array.Length} elements. Limit: {NetworkReader.AllocationLimit}");
 
-            writer.WriteUInt(checked((uint)array.Length) + 1u);
+            // most sizes are small, write size as VarUInt!
+            Compression.CompressVarUInt(writer, checked((uint)array.Length) + 1u);
+            // writer.WriteUInt(checked((uint)array.Length) + 1u);
             for (int i = 0; i < array.Length; i++)
                 writer.Write(array[i]);
         }

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -40,6 +40,15 @@ namespace Mirror
         public static void WriteULong(this NetworkWriter writer, ulong value) => writer.WriteBlittable(value);
         public static void WriteULongNullable(this NetworkWriter writer, ulong? value) => writer.WriteBlittableNullable(value);
 
+        // WriteInt/UInt/Long/ULong writes full bytes by default.
+        // define additional "_Compressed" versions that Weaver will automatically prefer.
+        // using VarInt compression for all users types gives significant bandwidth reductions.
+        // 99% of the time [SyncVar] ints are small values, which makes this worth it.
+        public static void WriteInt_Compressed(this NetworkWriter writer, int value) => Compression.CompressVarInt(writer, value);
+        public static void WriteUInt_Compressed(this NetworkWriter writer, uint value) => Compression.CompressVarUInt(writer, value);
+        public static void WriteLong_Compressed(this NetworkWriter writer, long value) => Compression.CompressVarInt(writer, value);
+        public static void WriteULong_Compressed(this NetworkWriter writer, ulong value) => Compression.CompressVarUInt(writer, value);
+
         public static void WriteFloat(this NetworkWriter writer, float value) => writer.WriteBlittable(value);
         public static void WriteFloatNullable(this NetworkWriter writer, float? value) => writer.WriteBlittableNullable(value);
 

--- a/Assets/Mirror/Core/NetworkWriterExtensions.cs
+++ b/Assets/Mirror/Core/NetworkWriterExtensions.cs
@@ -41,13 +41,12 @@ namespace Mirror
         public static void WriteULongNullable(this NetworkWriter writer, ulong? value) => writer.WriteBlittableNullable(value);
 
         // WriteInt/UInt/Long/ULong writes full bytes by default.
-        // define additional "_Compressed" versions that Weaver will automatically prefer.
-        // using VarInt compression for all users types gives significant bandwidth reductions.
-        // 99% of the time [SyncVar] ints are small values, which makes this worth it.
-        public static void WriteInt_Compressed(this NetworkWriter writer, int value) => Compression.CompressVarInt(writer, value);
-        public static void WriteUInt_Compressed(this NetworkWriter writer, uint value) => Compression.CompressVarUInt(writer, value);
-        public static void WriteLong_Compressed(this NetworkWriter writer, long value) => Compression.CompressVarInt(writer, value);
-        public static void WriteULong_Compressed(this NetworkWriter writer, ulong value) => Compression.CompressVarUInt(writer, value);
+        // define additional "VarInt" versions that Weaver will automatically prefer.
+        // 99% of the time [SyncVar] ints are small values, which makes this very much worth it.
+        [WeaverPriority] public static void WriteVarInt(this NetworkWriter writer, int value) => Compression.CompressVarInt(writer, value);
+        [WeaverPriority] public static void WriteVarUInt(this NetworkWriter writer, uint value) => Compression.CompressVarUInt(writer, value);
+        [WeaverPriority] public static void WriteVarLong(this NetworkWriter writer, long value) => Compression.CompressVarInt(writer, value);
+        [WeaverPriority] public static void WriteVarULong(this NetworkWriter writer, ulong value) => Compression.CompressVarUInt(writer, value);
 
         public static void WriteFloat(this NetworkWriter writer, float value) => writer.WriteBlittable(value);
         public static void WriteFloatNullable(this NetworkWriter writer, float? value) => writer.WriteBlittableNullable(value);

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -33,12 +33,25 @@ namespace Mirror.Weaver
 
         internal void Register(TypeReference dataType, MethodReference methodReference)
         {
-            if (readFuncs.ContainsKey(dataType))
+            // sometimes we define multiple read methods for the same type.
+            // for example:
+            //   ReadInt()     // alwasy writes 4 bytes: should be available to the user for binary protocols etc.
+            //   ReadVarInt()  // varint compression: we may want Weaver to always use this for minimal bandwidth
+            // give the user a way to define the weaver prefered one if two exists:
+            //   "_Weaver" suffix is automatically detected and prefered.
+            //   need to check for .Contains not .EndsWith because function names look like this:
+            //   "NetworkReaderExtensions::ReadInt_Weaver(Mirror.NetworkWriter,System.Int32)"
+            bool priority = methodReference.FullName.Contains(Weaver.PrioritySuffix);
+            // if (priority) Log.Warning($"Weaver: Registering priority Read<{dataType.FullName}> with {methodReference.FullName}.", methodReference);
+
+            // Weaver sometimes calls Register for <T> multiple times because we resolve assemblies multiple times.
+            // if the function name is the same: always use the latest one.
+            // if the function name differes: use the priority one.
+            if (readFuncs.TryGetValue(dataType, out MethodReference existingMethod) && // if it was already defined
+                existingMethod.FullName != methodReference.FullName && // and this one is a different name
+                !priority) // and it's not the priority one
             {
-                // TODO enable this again later.
-                // Reader has some obsolete functions that were renamed.
-                // Don't want weaver warnings for all of them.
-                //Log.Warning($"Registering a Read method for {dataType.FullName} when one already exists", methodReference);
+                return; // then skip
             }
 
             // we need to import type when we Initialize Readers so import here in case it is used anywhere else

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -38,10 +38,9 @@ namespace Mirror.Weaver
             //   ReadInt()     // alwasy writes 4 bytes: should be available to the user for binary protocols etc.
             //   ReadVarInt()  // varint compression: we may want Weaver to always use this for minimal bandwidth
             // give the user a way to define the weaver prefered one if two exists:
-            //   "_Weaver" suffix is automatically detected and prefered.
-            //   need to check for .Contains not .EndsWith because function names look like this:
-            //   "NetworkReaderExtensions::ReadInt_Weaver(Mirror.NetworkWriter,System.Int32)"
-            bool priority = methodReference.FullName.Contains(Weaver.PrioritySuffix);
+            //   "[WeaverPriority]" attribute is automatically detected and prefered.
+            MethodDefinition methodDefinition = methodReference.Resolve();
+            bool priority = methodDefinition.HasCustomAttribute<WeaverPriorityAttribute>();
             // if (priority) Log.Warning($"Weaver: Registering priority Read<{dataType.FullName}> with {methodReference.FullName}.", methodReference);
 
             // Weaver sometimes calls Register for <T> multiple times because we resolve assemblies multiple times.

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -19,6 +19,9 @@ namespace Mirror.Weaver
         // Mirror.dll name
         public const string MirrorAssemblyName = "Mirror";
 
+        // if two writers of same type are defined, prefer the one with this suffix
+        public const string PrioritySuffix = "_Compressed";
+
         WeaverTypes weaverTypes;
         SyncVarAccessLists syncVarAccessLists;
         AssemblyDefinition CurrentAssembly;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -19,9 +19,6 @@ namespace Mirror.Weaver
         // Mirror.dll name
         public const string MirrorAssemblyName = "Mirror";
 
-        // if two writers of same type are defined, prefer the one with this suffix
-        public const string PrioritySuffix = "_Compressed";
-
         WeaverTypes weaverTypes;
         SyncVarAccessLists syncVarAccessLists;
         AssemblyDefinition CurrentAssembly;

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -33,12 +33,25 @@ namespace Mirror.Weaver
 
         public void Register(TypeReference dataType, MethodReference methodReference)
         {
-            if (writeFuncs.ContainsKey(dataType))
+            // sometimes we define multiple write methods for the same type.
+            // for example:
+            //   WriteInt()     // alwasy writes 4 bytes: should be available to the user for binary protocols etc.
+            //   WriteVarInt()  // varint compression: we may want Weaver to always use this for minimal bandwidth
+            // give the user a way to define the weaver prefered one if two exists:
+            //   "_Weaver" suffix is automatically detected and prefered.
+            //   need to check for .Contains not .EndsWith because function names look like this:
+            //   "NetworkWriterExtensions::WriteInt_Weaver(Mirror.NetworkWriter,System.Int32)"
+            bool priority = methodReference.FullName.Contains(Weaver.PrioritySuffix);
+            // if (priority) Log.Warning($"Weaver: Registering priority Write<{dataType.FullName}> with {methodReference.FullName}.", methodReference);
+
+            // Weaver sometimes calls Register for <T> multiple times because we resolve assemblies multiple times.
+            // if the function name is the same: always use the latest one.
+            // if the function name differes: use the priority one.
+            if (writeFuncs.TryGetValue(dataType, out MethodReference existingMethod) && // if it was already defined
+                existingMethod.FullName != methodReference.FullName && // and this one is a different name
+                !priority) // and it's not the priority one
             {
-                // TODO enable this again later.
-                // Writer has some obsolete functions that were renamed.
-                // Don't want weaver warnings for all of them.
-                //Log.Warning($"Registering a Write method for {dataType.FullName} when one already exists", methodReference);
+                return; // then skip
             }
 
             // we need to import type when we Initialize Writers so import here in case it is used anywhere else

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -38,10 +38,9 @@ namespace Mirror.Weaver
             //   WriteInt()     // alwasy writes 4 bytes: should be available to the user for binary protocols etc.
             //   WriteVarInt()  // varint compression: we may want Weaver to always use this for minimal bandwidth
             // give the user a way to define the weaver prefered one if two exists:
-            //   "_Weaver" suffix is automatically detected and prefered.
-            //   need to check for .Contains not .EndsWith because function names look like this:
-            //   "NetworkWriterExtensions::WriteInt_Weaver(Mirror.NetworkWriter,System.Int32)"
-            bool priority = methodReference.FullName.Contains(Weaver.PrioritySuffix);
+            //   "[WeaverPriority]" attribute is automatically detected and prefered.
+            MethodDefinition methodDefinition = methodReference.Resolve();
+            bool priority = methodDefinition.HasCustomAttribute<WeaverPriorityAttribute>();
             // if (priority) Log.Warning($"Weaver: Registering priority Write<{dataType.FullName}> with {methodReference.FullName}.", methodReference);
 
             // Weaver sometimes calls Register for <T> multiple times because we resolve assemblies multiple times.

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterCollectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterCollectionTest.cs
@@ -6,24 +6,83 @@ namespace Mirror.Tests.NetworkReaderWriter
 {
     public class NetworkWriterCollectionTest
     {
-        // we defined WriteInt and WriteInt_Compressed. make sure it's using the priority one.
+        // we defined WriteInt and WriteVarInt. make sure it's using the priority one.
         [Test]
         public void UsesPriorityWriteFunctionForInt()
         {
             Assert.That(Writer<int>.write, Is.Not.Null, "int write function was not found");
 
-            Action<NetworkWriter, int> action = NetworkWriterExtensions.WriteInt_Compressed;
+            Action<NetworkWriter, int> action = NetworkWriterExtensions.WriteVarInt;
             Assert.That(Writer<int>.write, Is.EqualTo(action), "int write function was incorrect value");
         }
 
-        // we defined ReadInt and ReadInt_Compressed. make sure it's using the priority one.
+        // we defined ReadInt and ReadVarInt. make sure it's using the priority one.
         [Test]
         public void UsesPriorityReadFunctionForInt()
         {
             Assert.That(Reader<int>.read, Is.Not.Null, "int read function was not found");
 
-            Func<NetworkReader, int> action = NetworkReaderExtensions.ReadInt_Compressed;
+            Func<NetworkReader, int> action = NetworkReaderExtensions.ReadVarInt;
             Assert.That(Reader<int>.read, Is.EqualTo(action), "int read function was incorrect value");
+        }
+
+        // we defined WriteInt and WriteVarUInt. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityWriteFunctionForUInt()
+        {
+            Assert.That(Writer<uint>.write, Is.Not.Null, "uint write function was not found");
+
+            Action<NetworkWriter, uint> action = NetworkWriterExtensions.WriteVarUInt;
+            Assert.That(Writer<uint>.write, Is.EqualTo(action), "uint write function was incorrect value");
+        }
+
+        // we defined ReadInt and ReadVarInt. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityReadFunctionForUInt()
+        {
+            Assert.That(Reader<uint>.read, Is.Not.Null, "uint read function was not found");
+
+            Func<NetworkReader, uint> action = NetworkReaderExtensions.ReadVarUInt;
+            Assert.That(Reader<uint>.read, Is.EqualTo(action), "uint read function was incorrect value");
+        }
+        // we defined WriteInt and WriteVarInt. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityWriteFunctionForLong()
+        {
+            Assert.That(Writer<long>.write, Is.Not.Null, "long write function was not found");
+
+            Action<NetworkWriter, long> action = NetworkWriterExtensions.WriteVarLong;
+            Assert.That(Writer<long>.write, Is.EqualTo(action), "long write function was incorrect value");
+        }
+
+        // we defined ReadLong and ReadVarLong. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityReadFunctionForLong()
+        {
+            Assert.That(Reader<long>.read, Is.Not.Null, "long read function was not found");
+
+            Func<NetworkReader, long> action = NetworkReaderExtensions.ReadVarLong;
+            Assert.That(Reader<long>.read, Is.EqualTo(action), "long read function was incorrect value");
+        }
+
+        // we defined WriteLong and WriteVarULong. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityWriteFunctionForULong()
+        {
+            Assert.That(Writer<ulong>.write, Is.Not.Null, "ulong write function was not found");
+
+            Action<NetworkWriter, ulong> action = NetworkWriterExtensions.WriteVarULong;
+            Assert.That(Writer<ulong>.write, Is.EqualTo(action), "ulong write function was incorrect value");
+        }
+
+        // we defined ReadLong and ReadVarLong. make sure it's using the priority one.
+        [Test]
+        public void UsesPriorityReadFunctionForULong()
+        {
+            Assert.That(Reader<ulong>.read, Is.Not.Null, "ulong read function was not found");
+
+            Func<NetworkReader, ulong> action = NetworkReaderExtensions.ReadVarULong;
+            Assert.That(Reader<ulong>.read, Is.EqualTo(action), "ulong read function was incorrect value");
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterCollectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterCollectionTest.cs
@@ -6,21 +6,23 @@ namespace Mirror.Tests.NetworkReaderWriter
 {
     public class NetworkWriterCollectionTest
     {
+        // we defined WriteInt and WriteInt_Compressed. make sure it's using the priority one.
         [Test]
-        public void HasWriteFunctionForInt()
+        public void UsesPriorityWriteFunctionForInt()
         {
             Assert.That(Writer<int>.write, Is.Not.Null, "int write function was not found");
 
-            Action<NetworkWriter, int> action = NetworkWriterExtensions.WriteInt;
+            Action<NetworkWriter, int> action = NetworkWriterExtensions.WriteInt_Compressed;
             Assert.That(Writer<int>.write, Is.EqualTo(action), "int write function was incorrect value");
         }
 
+        // we defined ReadInt and ReadInt_Compressed. make sure it's using the priority one.
         [Test]
-        public void HasReadFunctionForInt()
+        public void UsesPriorityReadFunctionForInt()
         {
             Assert.That(Reader<int>.read, Is.Not.Null, "int read function was not found");
 
-            Func<NetworkReader, int> action = NetworkReaderExtensions.ReadInt;
+            Func<NetworkReader, int> action = NetworkReaderExtensions.ReadInt_Compressed;
             Assert.That(Reader<int>.read, Is.EqualTo(action), "int read function was incorrect value");
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
@@ -1405,7 +1405,7 @@ namespace Mirror.Tests.NetworkReaderWriter
             void WriteBadArray()
             {
                 // Reader/Writer encode null as count=0 and [] as count=1 (+1 offset)
-                writer.WriteUInt_Compressed((uint)(badLength+1)); // Reader/Writer encode size headers as VarInt
+                writer.WriteVarUInt((uint)(badLength+1)); // Reader/Writer encode size headers as VarInt
                 int[] array = new int[testArraySize] { 1, 2, 3, 4 };
                 for (int i = 0; i < array.Length; i++)
                     writer.Write(array[i]);

--- a/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkReaderWriter/NetworkWriterTest.cs
@@ -1405,7 +1405,7 @@ namespace Mirror.Tests.NetworkReaderWriter
             void WriteBadArray()
             {
                 // Reader/Writer encode null as count=0 and [] as count=1 (+1 offset)
-                writer.WriteUInt((uint)(badLength+1));
+                writer.WriteUInt_Compressed((uint)(badLength+1)); // Reader/Writer encode size headers as VarInt
                 int[] array = new int[testArraySize] { 1, 2, 3, 4 };
                 for (int i = 0; i < array.Length; i++)
                     writer.Write(array[i]);

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -17,12 +17,13 @@ namespace Mirror.Tests.NetworkServers
     {
         // weaver serializes byte[] wit WriteBytesAndSize
         public byte[] payload;
-        // so payload := size - 4
+        // so payload := size - header
+        //   where header is VarUInt compression(size)
         // then the message is exactly maxed size.
         //
         // NOTE: we have a LargerMaxMessageSize test which guarantees that
         //       variablesized + 1 is exactly transport.max + 1
-        public VariableSizedMessage(int size) => payload = new byte[size - 4];
+        public VariableSizedMessage(int size) => payload = new byte[size - Compression.VarUIntSize((uint)size)];
     }
 
     public class CommandTestNetworkBehaviour : NetworkBehaviour


### PR DESCRIPTION
# FIRST REAL WORLD TESTS:
- 2% worse CPU perf
- 15% better bandwidth

pending more tests to see if this is worth it.




**MERGE, DONT SQUASH**

automatically compress all game integers!

## Tanks OnSerialize
Before:
```cs
public override void SerializeSyncVars(NetworkWriter writer, bool forceAll)
{
    base.SerializeSyncVars(writer, forceAll);
    if (forceAll)
    {
        writer.WriteInt(health);
        return;
    }
    writer.WriteULong(syncVarDirtyBits);
    if ((syncVarDirtyBits & 1L) != 0L)
    {
        writer.WriteInt(health);
    }
}
```

After:
```cs
public override void SerializeSyncVars(NetworkWriter writer, bool forceAll)
{
    base.SerializeSyncVars(writer, forceAll);
    if (forceAll)
    {
        writer.WriteVarInt(health);
        return;
    }
    writer.WriteVarULong(syncVarDirtyBits);
    if ((syncVarDirtyBits & 1L) != 0L)
    {
        writer.WriteVarInt(health);
    }
}
```

# Benchmark:
- before: 120 KB/s
- after: 100 KB/s
![image](https://github.com/user-attachments/assets/ec50dece-d7ab-4655-be81-49a2643ae21a)