### PR TITLE
kcp shares buffer

### DIFF
--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
@@ -43,6 +43,29 @@ namespace kcp2k
             this.remoteEndPoint = remoteEndPoint;
         }
 
+        public KcpServerConnection(
+            Action<KcpServerConnection> OnConnected,
+            Action<ArraySegment<byte>, KcpChannel> OnData,
+            Action OnDisconnected,
+            Action<ErrorCode, string> OnError,
+            Action<ArraySegment<byte>> OnRawSend,
+            KcpConfig config,
+            uint cookie,
+            EndPoint remoteEndPoint,
+            byte[] rawSendBuffer,
+            byte[] kcpMessageBuffer,
+            byte[] kcpSendBuffer)
+            : base(config, cookie, rawSendBuffer, kcpMessageBuffer, rawSendBuffer)
+        {
+            OnConnectedCallback = OnConnected;
+            OnDataCallback = OnData;
+            OnDisconnectedCallback = OnDisconnected;
+            OnErrorCallback = OnError;
+            RawSendCallback = OnRawSend;
+
+            this.remoteEndPoint = remoteEndPoint;
+        }
+
         // callbacks ///////////////////////////////////////////////////////////
         protected override void OnAuthenticated()
         {

--- a/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
+++ b/Assets/Mirror/Transports/KCP/kcp2k/highlevel/KcpServerConnection.cs
@@ -55,7 +55,7 @@ namespace kcp2k
             byte[] rawSendBuffer,
             byte[] kcpMessageBuffer,
             byte[] kcpSendBuffer)
-            : base(config, cookie, rawSendBuffer, kcpMessageBuffer, rawSendBuffer)
+            : base(config, cookie, rawSendBuffer, kcpMessageBuffer, kcpSendBuffer)
         {
             OnConnectedCallback = OnConnected;
             OnDataCallback = OnData;


### PR DESCRIPTION
while kcp2k is single-threaded and the peer's config never changes, there is no need to allocate 3 buffers for every peer. 
when there are many peers, it will result in high memory usage.