### PR TITLE
fix: Examples colliders and missing namespace.

### DIFF
--- a/Assets/Mirror/Examples/CouchCoop/MirrorCouchCoop.unity
+++ b/Assets/Mirror/Examples/CouchCoop/MirrorCouchCoop.unity
@@ -165,7 +165,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &34377706
 MeshRenderer:
@@ -258,7 +258,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &80415369
 MeshRenderer:
@@ -497,7 +497,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &121552836
 MeshRenderer:
@@ -642,7 +642,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &388677688
 MeshRenderer:
@@ -792,7 +792,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &446496355
 MeshRenderer:
@@ -928,7 +928,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &498523325
 MeshRenderer:
@@ -1183,7 +1183,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &738449928
 MeshRenderer:
@@ -1319,7 +1319,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &828682888
 MeshRenderer:
@@ -1412,7 +1412,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &898358223
 MeshRenderer:
@@ -1697,7 +1697,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1179387014
 MeshRenderer:
@@ -1829,7 +1829,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1218169083
 MeshRenderer:
@@ -1922,7 +1922,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1263590062
 MeshRenderer:
@@ -2091,7 +2091,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1284513254
 MeshRenderer:
@@ -2565,7 +2565,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &1648326111
 MeshRenderer:
@@ -3174,7 +3174,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!23 &2105958124
 MeshRenderer:

--- a/Assets/Mirror/Examples/CouchCoop/Scripts/PlatformMovement.cs
+++ b/Assets/Mirror/Examples/CouchCoop/Scripts/PlatformMovement.cs
@@ -1,46 +1,49 @@
 using UnityEngine;
 using Mirror;
 
-public class PlatformMovement : NetworkBehaviour
+namespace Mirror.Examples.CouchCoop
 {
-    // A separate script to handle platform behaviour, see its partner script, MovingPlatform.cs
-    private bool onPlatform;
-    private Transform platformTransform;
-    private Vector3 lastPlatformPosition;
-
-    public override void OnStartAuthority()
+    public class PlatformMovement : NetworkBehaviour
     {
-        this.enabled = true;
-    }
+        // A separate script to handle platform behaviour, see its partner script, MovingPlatform.cs
+        private bool onPlatform;
+        private Transform platformTransform;
+        private Vector3 lastPlatformPosition;
 
-    void FixedUpdate()
-    {
-        if (onPlatform)
+        public override void OnStartAuthority()
         {
-            Vector3 deltaPosition = platformTransform.position - lastPlatformPosition;
-            transform.position += deltaPosition;
-            lastPlatformPosition = platformTransform.position;
+            this.enabled = true;
         }
-    }
 
-    private void OnCollisionEnter(Collision collision)
-    {
-        
-        if (collision.gameObject.tag == "Finish")
+        void FixedUpdate()
         {
-            platformTransform = collision.gameObject.GetComponent<Transform>();
-            lastPlatformPosition = platformTransform.position;
-            onPlatform = true;
+            if (onPlatform)
+            {
+                Vector3 deltaPosition = platformTransform.position - lastPlatformPosition;
+                transform.position += deltaPosition;
+                lastPlatformPosition = platformTransform.position;
+            }
         }
-    }
 
-    private void OnCollisionExit(Collision collision)
-    {
-        // ideally set a Platform tag, but we'l just use a Unity Pre-set.
-        if (collision.gameObject.tag == "Finish")
+        private void OnCollisionEnter(Collision collision)
         {
-            onPlatform = false;
-            platformTransform = null;
+
+            if (collision.gameObject.tag == "Finish")
+            {
+                platformTransform = collision.gameObject.GetComponent<Transform>();
+                lastPlatformPosition = platformTransform.position;
+                onPlatform = true;
+            }
+        }
+
+        private void OnCollisionExit(Collision collision)
+        {
+            // ideally set a Platform tag, but we'l just use a Unity Pre-set.
+            if (collision.gameObject.tag == "Finish")
+            {
+                onPlatform = false;
+                platformTransform = null;
+            }
         }
     }
 }

--- a/Assets/Mirror/Examples/TopDownShooter/Prefabs/EnemyPrefab.prefab
+++ b/Assets/Mirror/Examples/TopDownShooter/Prefabs/EnemyPrefab.prefab
@@ -539,7 +539,7 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 2, y: 2, z: 2}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0.5, z: -0.1}
 --- !u!114 &4118329204170882586
 MonoBehaviour:


### PR DESCRIPTION
No idea what happened, but some colliders seem to have changed their size.
Also added missing namespace to the 2 latest platform scripts on CouchCoop example.

<img width="226" alt="Screenshot_2024-08-01_at_18 41 37" src="https://github.com/user-attachments/assets/33951df6-5add-4e10-9f77-8cb7a07995d8">

<img width="464" alt="Screenshot 2024-08-01 at 18 38 09" src="https://github.com/user-attachments/assets/ac48f407-c1aa-459a-b7b4-89962d893b12">


