### PR TITLE
fix(NetworkClient): InvokeIdentityCallbacks call OnStartClient first

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1493,11 +1493,11 @@ namespace Mirror
         // cleaner, and some places need to set flags first.
         static void InvokeIdentityCallbacks(NetworkIdentity identity)
         {
-            // invoke OnStartAuthority
-            identity.NotifyAuthority();
-
             // invoke OnStartClient
             identity.OnStartClient();
+
+            // invoke OnStartAuthority
+            identity.NotifyAuthority();
 
             // invoke OnStartLocalPlayer
             if (identity.isLocalPlayer)


### PR DESCRIPTION
- This is for host client to match logical call order as remote client

```cs
public override void OnStartClient()
{
    Debug.Log($"OnStartClient: {isOwned} {isLocalPlayer}");
}

public override void OnStartAuthority()
{
    Debug.Log($"OnStartAuthority: {isOwned} {isLocalPlayer}");
}

public override void OnStartLocalPlayer()
{
    Debug.Log($"OnStartLocalPlayer: {isOwned} {isLocalPlayer}");
}
```

Host Client
![image](https://github.com/user-attachments/assets/b6c2a5dd-70a4-4f5b-8c88-482c607b98c8)

Remote Client
![image](https://github.com/user-attachments/assets/47b893e5-5563-4a67-b453-0feb79553ad5)
