### PR TITLE
Ensure NetworkServer doesn't throw unexpected command exceptions

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -336,13 +336,19 @@ namespace Mirror
                 {
                     // Attempt to identify the target object, component, and method to narrow down the cause of the error.
                     if (spawned.TryGetValue(msg.netId, out NetworkIdentity netIdentity))
+                    {
+                        if (netIdentity == null)
+                        {
+                            Debug.LogWarning($"Command received for non-existent netIdentity:{msg.netId} when client not ready.");
+                            return;
+                        }
                         if (msg.componentIndex < netIdentity.NetworkBehaviours.Length && netIdentity.NetworkBehaviours[msg.componentIndex] is NetworkBehaviour component)
                             if (RemoteProcedureCalls.GetFunctionMethodName(msg.functionHash, out string methodName))
                             {
                                 Debug.LogWarning($"Command {methodName} received for {netIdentity.name} [netId={msg.netId}] component {component.name} [index={msg.componentIndex}] when client not ready.\nThis may be ignored if client intentionally set NotReady.");
                                 return;
                             }
-
+                    }
                     Debug.LogWarning("Command received while client is not ready.\nThis may be ignored if client intentionally set NotReady.");
                 }
                 return;


### PR DESCRIPTION
It is possible to receive a command with netId = 0 on a reliable channel, which will result in a null netIdentity. The attempt to show the method name will fail as it never null checks the output of TryGetValue(netId)

This change adds a null check before the attempt to isolate the function that the caller tried to invoke on the server.