### PR TITLE
fix(ThreadedTransport): sleep detection

### DIFF
--- a/Assets/Mirror/Transports/Threaded/ThreadedTransport.cs
+++ b/Assets/Mirror/Transports/Threaded/ThreadedTransport.cs
@@ -148,7 +148,7 @@ namespace Mirror
         const int MaxProcessingPerTick = 10_000_000;
 
         [Tooltip("Detect device sleep mode and automatically disconnect + hibernate the thread after 'sleepTimeout' seconds.\nFor example: on mobile / VR, we don't want to drain the battery after putting down the device.")]
-        public bool sleepDetection = false;
+        public bool sleepDetection = true;
         public float sleepTimeout = 30;
 
         // communication between main & worker thread //////////////////////////

--- a/Assets/Mirror/Transports/Threaded/ThreadedTransport.cs
+++ b/Assets/Mirror/Transports/Threaded/ThreadedTransport.cs
@@ -149,7 +149,7 @@ namespace Mirror
 
         [Tooltip("Detect device sleep mode and automatically disconnect + hibernate the thread after 'sleepTimeout' seconds.\nFor example: on mobile / VR, we don't want to drain the battery after putting down the device.")]
         public bool sleepDetection = true;
-        public float sleepTimeout = 30;
+        public float sleepTimeoutInSeconds = 30;
 
         // communication between main & worker thread //////////////////////////
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -278,7 +278,7 @@ namespace Mirror
                         // start the sleep timer if not started yet
                         if (sleepTimer == null)
                         {
-                            Debug.Log($"ThreadedTransport: sleep detected, sleeping in {sleepTimeout:F0}s!");
+                            Debug.Log($"ThreadedTransport: sleep detected, sleeping in {sleepTimeoutInSeconds:F0}s!");
                             sleepTimer = Stopwatch.StartNew();
                         }
                         break;
@@ -311,7 +311,7 @@ namespace Mirror
         {
             // was the device put to sleep?
             if (sleepTimer != null &&
-                sleepTimer.Elapsed.TotalSeconds >= sleepTimeout)
+                sleepTimer.Elapsed.TotalSeconds >= sleepTimeoutInSeconds)
             {
                 Debug.Log("ThreadedTransport: entering sleep mode and stopping/disconnecting.");
                 ThreadedServerStop();


### PR DESCRIPTION
**optional feature**: ThreadedTransport automatically detects if a device was put to sleep (i.e. phone/VR/etc.)
after a configurable timeout, it then ends the worker thread gracefully.

this is important so we don't drain devices that were put to sleep, and may stay asleep for days.