### PR TITLE
fix(Batching): add timestamp safety check to ensure all messages in the batch have the same timestamp

### DIFF
--- a/Assets/Mirror/Core/Batching/Batcher.cs
+++ b/Assets/Mirror/Core/Batching/Batcher.cs
@@ -49,8 +49,16 @@ namespace Mirror
         // => best to build batches on the fly.
         readonly Queue<NetworkWriterPooled> batches = new Queue<NetworkWriterPooled>();
 
-        // current batch in progress
+        // current batch in progress.
+        // we also store the timestamp to ensure we don't add a message from another frame,
+        // as this would introduce subtle jitter!
+        //
+        // for example:
+        // - a batch is started at t=1, another message is added at t=2 and then it's flushed
+        // - NetworkTransform uses remoteTimestamp which is t=1
+        // - snapshot interpolation would off by one (or multiple) frames!
         NetworkWriterPooled batch;
+        double batchTimestamp;
 
         public Batcher(int threshold)
         {
@@ -62,6 +70,32 @@ namespace Mirror
         // caller needs to make sure they are within max packet size.
         public void AddMessage(ArraySegment<byte> message, double timeStamp)
         {
+            // safety: message timestamp is only written once.
+            // make sure all messages in this batch are from the same timestamp.
+            // otherwise it could silently introduce jitter.
+            //
+            // this happened before:
+            // - NetworkEarlyUpdate @ t=1 processes transport messages
+            //   - a handler replies by sending a message
+            //     - a new batch is started @ t=1, timestamp is encoded
+            // - NetworkLateUpdate @ t=2 decides it's time to broadcast
+            //   - NetworkTransform sends @ t=2
+            //     - we add to the above batch which already encoded t=1
+            // - Client receives the batch which timestamp t=1
+            //   - NetworkTransform uses remoteTime for interpolation
+            //     remoteTime is the batch timestamp which is t=1
+            //     - the NetworkTransform message is actually t=2
+            // => smooth interpolation would be impossible!
+            //    NT thinks the position was @ t=1 but actually it was @ t=2 !
+            //
+            // the solution: if timestamp changed, enqueue the existing batch
+            if (batch != null && batchTimestamp != timeStamp)
+            {
+                batches.Enqueue(batch);
+                batch = null;
+                batchTimestamp = 0;
+            }
+
             // predict the needed size, which is varint(size) + content
             int headerSize = Compression.VarUIntSize((ulong)message.Count);
             int neededSize = headerSize + message.Count;
@@ -76,6 +110,7 @@ namespace Mirror
             {
                 batches.Enqueue(batch);
                 batch = null;
+                batchTimestamp = 0;
             }
 
             // initialize a new batch if necessary
@@ -89,6 +124,9 @@ namespace Mirror
                 // -> batches are per-frame, it doesn't matter which message's
                 //    timestamp we use.
                 batch.WriteDouble(timeStamp);
+
+                // remember the encoded timestamp, see safety check below.
+                batchTimestamp = timeStamp;
             }
 
             // add serialization to current batch. even if > threshold.
@@ -155,6 +193,7 @@ namespace Mirror
             {
                 NetworkWriterPool.Return(batch);
                 batch = null;
+                batchTimestamp = 0;
             }
 
             // return all queued batches

--- a/Assets/Mirror/Tests/Editor/Batching/BatcherTests.cs
+++ b/Assets/Mirror/Tests/Editor/Batching/BatcherTests.cs
@@ -56,6 +56,45 @@ namespace Mirror.Tests.Batching
             batcher.AddMessage(new ArraySegment<byte>(message), TimeStamp);
         }
 
+        // test to prevent the following issue from ever happening again:
+        //
+        // - NetworkEarlyUpdate @ t=1 processes transport messages
+        //   - a handler replies by sending a message
+        //     - a new batch is started @ t=1, timestamp is encoded
+        // - NetworkLateUpdate @ t=2 decides it's time to broadcast
+        //   - NetworkTransform sends @ t=2
+        //     - we add to the above batch which already encoded t=1
+        // - Client receives the batch which timestamp t=1
+        //   - NetworkTransform uses remoteTime for interpolation
+        //     remoteTime is the batch timestamp which is t=1
+        //     - the NetworkTransform message is actually t=2
+        // => smooth interpolation would be impossible!
+        //    NT thinks the position was @ t=1 but actually it was @ t=2 !
+        [Test]
+        public void AddMessage_TimestampMismatch()
+        {
+            // add message @ t=1
+            byte[] message1 = {0x01, 0x01};
+            batcher.AddMessage(new ArraySegment<byte>(message1), 1);
+
+            // add message @ t=2
+            byte[] message2 = {0x02, 0x02};
+            batcher.AddMessage(new ArraySegment<byte>(message2), 2);
+
+            // call getbatch: this should only contain the message @ t=1 !
+            // <<tickTimeStamp:8, message>>
+            bool result = batcher.GetBatch(writer);
+            Assert.That(result, Is.EqualTo(true));
+            Assert.That(writer.ToArray().SequenceEqual(MakeBatch(1, message1)));
+
+            // call getbatch: this should now contain the message @ t=2 !
+            // <<tickTimeStamp:8, message>>
+            writer.Position = 0;
+            result = batcher.GetBatch(writer);
+            Assert.That(result, Is.EqualTo(true));
+            Assert.That(writer.ToArray().SequenceEqual(MakeBatch(2, message2)));
+        }
+
         [Test]
         public void MakeNextBatch_OnlyAcceptsFreshWriter()
         {


### PR DESCRIPTION
fixes subtle jitter in all Mirror games.

### before
https://github.com/user-attachments/assets/c26f2213-cb70-404f-b241-177c65fc42dd

### after
https://github.com/user-attachments/assets/f081cd8d-06e1-4ea3-b93b-465e897a4ff6


fortunately we know who did this.
![image](https://github.com/user-attachments/assets/98144cb8-c5d6-4871-bd4c-67f885011d1d)
