### PR TITLE
SyncList: keep old OnChange parameters to not break projects

### DIFF
--- a/Assets/Mirror/Core/SyncList.cs
+++ b/Assets/Mirror/Core/SyncList.cs
@@ -33,9 +33,7 @@ namespace Mirror
         /// <para>For OP_SET and OP_REMOVE, T is the OLD value of the entry.</para>
         /// <para>For OP_CLEAR, T is default.</para>
         /// </summary>
-        // DEPRECATED 2024-10-14
         // TODO deprecate in favor of explicit Callback, later rename Callback to OnChange for consistency with other SyncCollections.
-        [Obsolete("SyncList.OnChange(op, index, item) is obsolete. Use SyncList.Callback(op, index, oldItem, newItem) instead.")]
         public Action<Operation, int, T> OnChange;
 
         /// <summary>
@@ -121,37 +119,27 @@ namespace Mirror
             {
                 case Operation.OP_ADD:
                     OnAdd?.Invoke(itemIndex);
- #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, newItem);
- #pragma warning restore CS0618
                     Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_INSERT:
                     OnInsert?.Invoke(itemIndex);
- #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, newItem);
- #pragma warning restore CS0618
                     Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_SET:
                     OnSet?.Invoke(itemIndex, oldItem);
- #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, oldItem);
- #pragma warning restore CS0618
                     Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_REMOVEAT:
                     OnRemove?.Invoke(itemIndex, oldItem);
- #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, oldItem);
- #pragma warning restore CS0618
                     Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_CLEAR:
                     OnClear?.Invoke();
- #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, default);
- #pragma warning restore CS0618
                     Callback?.Invoke(op, itemIndex, default, default);
                     break;
             }

--- a/Assets/Mirror/Core/SyncList.cs
+++ b/Assets/Mirror/Core/SyncList.cs
@@ -33,7 +33,18 @@ namespace Mirror
         /// <para>For OP_SET and OP_REMOVE, T is the OLD value of the entry.</para>
         /// <para>For OP_CLEAR, T is default.</para>
         /// </summary>
+        // DEPRECATED 2024-10-14
+        // TODO deprecate in favor of explicit Callback, later rename Callback to OnChange for consistency with other SyncCollections.
+        [Obsolete("SyncList.OnChange(op, index, item) is obsolete. Use SyncList.Callback(op, index, oldItem, newItem) instead.")]
         public Action<Operation, int, T> OnChange;
+
+        /// <summary>
+        /// This is called for all changes to the List.
+        /// Parameters: Operation, index, oldItem, newItem.
+        /// Sometimes we need both oldItem and newItem.
+        /// Keep for compatibility since 10 years of projects use this.
+        /// </summary>
+        public Action<Operation, int, T, T> Callback;
 
         /// <summary>This is called before the list is cleared so the list can be iterated</summary>
         public Action OnClear;
@@ -110,23 +121,38 @@ namespace Mirror
             {
                 case Operation.OP_ADD:
                     OnAdd?.Invoke(itemIndex);
+ #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, newItem);
+ #pragma warning restore CS0618
+                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_INSERT:
                     OnInsert?.Invoke(itemIndex);
+ #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, newItem);
+ #pragma warning restore CS0618
+                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_SET:
                     OnSet?.Invoke(itemIndex, oldItem);
+ #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, oldItem);
+ #pragma warning restore CS0618
+                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_REMOVEAT:
                     OnRemove?.Invoke(itemIndex, oldItem);
+ #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, oldItem);
+ #pragma warning restore CS0618
+                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_CLEAR:
                     OnClear?.Invoke();
+ #pragma warning disable CS0618
                     OnChange?.Invoke(op, itemIndex, default);
+ #pragma warning restore CS0618
+                    Callback?.Invoke(op, itemIndex, default, default);
                     break;
             }
         }

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
@@ -56,6 +56,14 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(clientList[itemIndex].item.price, Is.EqualTo(15));
                 callbackCalled = true;
             };
+            clientList.Callback = (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
+            {
+                Assert.That(op == SyncList<TestPlayer>.Operation.OP_SET, Is.True);
+                Assert.That(itemIndex, Is.EqualTo(0));
+                Assert.That(oldItem.item.price, Is.EqualTo(10));
+                Assert.That(newItem.item.price, Is.EqualTo(15));
+                callbackCalled = true;
+            };
 
             SyncListTest.SerializeDeltaTo(serverList, clientList);
             Assert.IsTrue(callbackCalled);

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
@@ -105,6 +105,13 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_CLEAR));
                 Assert.That(clientSyncList.Count, Is.EqualTo(3));
             };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_CLEAR));
+                Assert.That(clientSyncList.Count, Is.EqualTo(3));
+            };
 
             bool actionCalled = false;
             clientSyncList.OnClear = () =>
@@ -131,6 +138,14 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_INSERT));
                 Assert.That(index, Is.EqualTo(0));
                 Assert.That(clientSyncList[index], Is.EqualTo("yay"));
+            };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_INSERT));
+                Assert.That(index, Is.EqualTo(0));
+                Assert.That(newItem, Is.EqualTo("yay"));
             };
 
             bool actionCalled = false;
@@ -168,6 +183,15 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(clientSyncList[index], Is.EqualTo("yay"));
             };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_SET));
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(newItem, Is.EqualTo("yay"));
+            };
 
             bool actionCalled = false;
             clientSyncList.OnSet = (index, oldItem) =>
@@ -198,6 +222,15 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(oldItem, Is.EqualTo("World"));
                 Assert.That(clientSyncList[index], Is.EqualTo(null));
             };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_SET));
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(newItem, Is.EqualTo(null));
+            };
 
             bool actionCalled = false;
             clientSyncList.OnSet = (index, oldItem) =>
@@ -216,6 +249,7 @@ namespace Mirror.Tests.SyncCollections
 
             // clear handlers so we don't get called again
             clientSyncList.OnChange = null;
+            clientSyncList.Callback = null;
             clientSyncList.OnSet = null;
 
             serverSyncList[1] = "yay";
@@ -228,6 +262,14 @@ namespace Mirror.Tests.SyncCollections
         {
             bool called = false;
             clientSyncList.OnChange = (op, index, oldItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
+                Assert.That(index, Is.EqualTo(0));
+                Assert.That(oldItem, Is.Not.EqualTo("!"));
+            };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -272,6 +314,14 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(index, Is.EqualTo(1));
                 Assert.That(oldItem, Is.EqualTo("World"));
             };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
 
             bool actionCalled = false;
             clientSyncList.OnRemove = (index, oldItem) =>
@@ -293,6 +343,14 @@ namespace Mirror.Tests.SyncCollections
         {
             bool called = false;
             clientSyncList.OnChange = (op, index, oldItem) =>
+            {
+                called = true;
+
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+            };
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -438,11 +496,21 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(newItem, Is.EqualTo("yay"));
                 Assert.That(clientSyncList[index], Is.EqualTo("yay"));
             };
+            bool callbackActionCalled = false;
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                callbackActionCalled = true;
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_ADD));
+                Assert.That(index, Is.EqualTo(3));
+                Assert.That(oldItem, Is.Null);
+                Assert.That(newItem, Is.EqualTo("yay"));
+            };
 
             serverSyncList.Add("yay");
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
+            Assert.That(callbackActionCalled, Is.True);
         }
 
         [Test]
@@ -463,11 +531,19 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
                 Assert.That(index, Is.EqualTo(1));
             };
+            bool callbackActionCalled = false;
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                callbackActionCalled = true;
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
+                Assert.That(index, Is.EqualTo(1));
+            };
 
             serverSyncList.Remove("World");
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
+            Assert.That(callbackActionCalled, Is.True);
         }
 
         [Test]
@@ -489,11 +565,21 @@ namespace Mirror.Tests.SyncCollections
                 Assert.That(index, Is.EqualTo(1));
                 Assert.That(oldItem, Is.EqualTo("World"));
             };
+            bool callbackActionCalled = false;
+            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            {
+                callbackActionCalled = true;
+                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
+                Assert.That(index, Is.EqualTo(1));
+                Assert.That(oldItem, Is.EqualTo("World"));
+                Assert.That(newItem, Is.Null);
+            };
 
             serverSyncList.RemoveAt(1);
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
+            Assert.That(callbackActionCalled, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
we've had 10 years worth of projects hook into SyncLists for changes with (oldItem, newItem).
reducing this to one parameter that is sometimes oldItem, sometimes newItem introduces too much pain when upgrading.

this will save people thousands of dollars in upgrade costs.