### PR TITLE
fix: NetworkIdentity component bitmask shifting overflows

### DIFF
--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -863,7 +863,7 @@ namespace Mirror
             for (int i = 0; i < components.Length; ++i)
             {
                 NetworkBehaviour component = components[i];
-                ulong nthBit = (1u << i);
+                ulong nthBit = 1ul << i;
 
                 bool dirty = component.IsDirty();
 
@@ -910,7 +910,7 @@ namespace Mirror
 
                 // on client, only consider owned components with SyncDirection to server
                 NetworkBehaviour component = components[i];
-                ulong nthBit = (1u << i);
+                ulong nthBit = 1ul << i;
 
                 if (isOwned && component.syncDirection == SyncDirection.ClientToServer)
                 {
@@ -928,7 +928,7 @@ namespace Mirror
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsDirty(ulong mask, int index)
         {
-            ulong nthBit = (ulong)(1 << index);
+            ulong nthBit = 1ul << index;
             return (mask & nthBit) != 0;
         }
 


### PR DESCRIPTION
Thanks to EnragedOxygen on Discord for tracking this one down!

Turns out you need to be very explicit with typing otherwise c# will default to int. 
This will cause the component dirty mask to overflow for any components > 32, which causes weird issues since it will cancel each other out (both the bitmask creation and the following IsDirty(componentIndex) overflow)
This will lead to serialization on the component index < 32 and > 32 (so index 33 would deserialize for both 1 and 33), but only sometimes
Generally in real games this would show up as a size mismatch which is how EnragedOxygen discovered it

I've done a quick project wide search for any other occurences, but it seems like everywhere else is typed correctly