### PR TITLE
fix(PredictionUtils): move freeze rotation before constraints

### DIFF
--- a/Assets/Mirror/Components/PredictedRigidbody/PredictionUtils.cs
+++ b/Assets/Mirror/Components/PredictedRigidbody/PredictionUtils.cs
@@ -32,6 +32,8 @@ namespace Mirror
             rigidbodyCopy.isKinematic = original.isKinematic;
             rigidbodyCopy.interpolation = original.interpolation;
             rigidbodyCopy.collisionDetectionMode = original.collisionDetectionMode;
+            // fix: need to set freezeRotation before constraints:
+            // https://github.com/MirrorNetworking/Mirror/pull/3946
             rigidbodyCopy.freezeRotation = original.freezeRotation;
             rigidbodyCopy.constraints = original.constraints;
             rigidbodyCopy.sleepThreshold = original.sleepThreshold;

--- a/Assets/Mirror/Components/PredictedRigidbody/PredictionUtils.cs
+++ b/Assets/Mirror/Components/PredictedRigidbody/PredictionUtils.cs
@@ -32,9 +32,9 @@ namespace Mirror
             rigidbodyCopy.isKinematic = original.isKinematic;
             rigidbodyCopy.interpolation = original.interpolation;
             rigidbodyCopy.collisionDetectionMode = original.collisionDetectionMode;
+            rigidbodyCopy.freezeRotation = original.freezeRotation;
             rigidbodyCopy.constraints = original.constraints;
             rigidbodyCopy.sleepThreshold = original.sleepThreshold;
-            rigidbodyCopy.freezeRotation = original.freezeRotation;
 
             // moving (Configurable)Joints messes up their range of motion unless
             // we reset to initial position first (we do this in PredictedRigibody.cs).


### PR DESCRIPTION
The freezeRotation was overriding the constraints in PredictionUtils.MoveRigidbody
It is indeed a setter and when you set freezeRotation to false it clears all the three flags freezeX, freezeY, freezeZ, so it has to be set before the constraints