### PR TITLE
fix(InterestManagementBase): Improve SetHostVisibility

### DIFF
--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -46,6 +46,24 @@ namespace Mirror
         {
             foreach (Renderer rend in identity.GetComponentsInChildren<Renderer>())
                 rend.enabled = visible;
+
+            foreach (Light light in identity.GetComponentsInChildren<Light>())
+                light.enabled = visible;
+
+            foreach (AudioSource audio in identity.GetComponentsInChildren<AudioSource>())
+                audio.enabled = visible;
+
+            foreach (Terrain terrain in identity.GetComponentsInChildren<Terrain>())
+            {
+                terrain.drawHeightmap = visible;
+                terrain.drawTreesAndFoliage = visible;
+            }
+
+            foreach (ParticleSystem particle in identity.GetComponentsInChildren<ParticleSystem>())
+            {
+                ParticleSystem.EmissionModule emission = particle.emission;
+                emission.enabled = visible;
+            }
         }
 
         /// <summary>Called on the server when a new networked object is spawned.</summary>

--- a/Assets/Mirror/Core/InterestManagementBase.cs
+++ b/Assets/Mirror/Core/InterestManagementBase.cs
@@ -47,6 +47,14 @@ namespace Mirror
             foreach (Renderer rend in identity.GetComponentsInChildren<Renderer>())
                 rend.enabled = visible;
 
+            // reason to also set lights/audio/terrain/etc.:
+            // Let's say players were holding a flashlight or magic wand with a particle effect. Without this, 
+            // host client would see the light / particles for all players in all subscenes because we don't 
+            // hide lights and particles. Host client would hear ALL audio sources in all subscenes too. We 
+            // hide the renderers, which covers basic objects and UI, but we don't hide anything else that may 
+            // be a child of a networked object. Same idea for cars with lights and sounds in other subscenes 
+            // that host client shouldn't see or hear...host client wouldn't see the car itself, but sees the 
+            // lights moving around and hears all of their engines / horns / etc.
             foreach (Light light in identity.GetComponentsInChildren<Light>())
                 light.enabled = visible;
 


### PR DESCRIPTION
Tested in Additive Levels example by adding terrains with tree details, spot lights, audio sources, and particle systems to each of the two subscenes. Turn sound on / unmute the audio when playing the video below.

- Note that this is a virtual method, works by default for all interest mgmt, and can be overridden.

https://github.com/user-attachments/assets/d06a355a-9f46-45f5-83bb-297e5a2e6974

