### PR TITLE
fix(NetworkClient): Defer ApplySpawnPayload until OnObjectSpawnFinished #3097

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1106,13 +1106,14 @@ namespace Mirror
         // spawning ////////////////////////////////////////////////////////////
         internal static void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage message)
         {
+            // add to spawned first because DeserializeClient may need it for SyncVars
+            spawned[message.netId] = identity;
+
             if (message.assetId != 0)
                 identity.assetId = message.assetId;
 
             if (!identity.gameObject.activeSelf)
-            {
                 identity.gameObject.SetActive(true);
-            }
 
             // apply local values for VR support
             identity.transform.localPosition = message.position;
@@ -1123,8 +1124,11 @@ namespace Mirror
             // the below DeserializeClient call invokes SyncVarHooks.
             // flags always need to be initialized before that.
             // fixes: https://github.com/MirrorNetworking/Mirror/issues/3259
-            identity.isOwned = message.isOwner;
             identity.netId = message.netId;
+            identity.isOwned = message.isOwner;
+
+            if (identity.isOwned)
+                connection?.owned.Add(identity);
 
             if (message.isLocalPlayer)
                 InternalAddPlayer(identity);
@@ -1146,9 +1150,6 @@ namespace Mirror
                     identity.DeserializeClient(payloadReader, true);
                 }
             }
-
-            spawned[message.netId] = identity;
-            if (identity.isOwned) connection?.owned.Add(identity);
 
             // the initial spawn with OnObjectSpawnStarted/Finished calls all
             // object's OnStartClient/OnStartLocalPlayer after they were all
@@ -1298,8 +1299,11 @@ namespace Mirror
         {
             // Debug.Log("SpawnStarted");
             PrepareToSpawnSceneObjects();
+            pendingSpawns.Clear();
             isSpawnFinished = false;
         }
+
+        static Dictionary<NetworkIdentity, SpawnMessage> pendingSpawns = new Dictionary<NetworkIdentity, SpawnMessage>();
 
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {
@@ -1312,10 +1316,25 @@ namespace Mirror
                 // they are destroyed. for safety, let's double check here.
                 if (identity != null)
                 {
+                    // We may have deferred ApplySpawnPayload in OnSpawn
+                    // to avoid cross-reference race conditions with SyncVars.
+                    // Apply payload before invoking OnStartClient etc. callbacks
+                    // so that all data is there when they are invoked.
+                    // Note that Interest Management may not have updated spawned
+                    // dictionary yet, so not all identities may be in pendingSpawns.
+                    // Generally that's user error in their code, so we don't throw
+                    // a warning here, but keep the warning code for debugging if needed.
+                    if (pendingSpawns.TryGetValue(identity, out SpawnMessage message))
+                        ApplySpawnPayload(identity, message);
+                    //else
+                    //    Debug.LogWarning($"Expected pendingSpawns to contain {identity}: {identity.netId} but didn't");
+
                     BootstrapIdentity(identity);
                 }
                 else Debug.LogWarning("Found null entry in NetworkClient.spawned. This is unexpected. Was the NetworkIdentity not destroyed properly?");
             }
+
+            pendingSpawns.Clear();
             isSpawnFinished = true;
         }
 
@@ -1437,7 +1456,16 @@ namespace Mirror
             // Debug.Log($"Client spawn handler instantiating netId={msg.netId} assetID={msg.assetId} sceneId={msg.sceneId:X} pos={msg.position}");
             if (FindOrSpawnObject(message, out NetworkIdentity identity))
             {
-                ApplySpawnPayload(identity, message);
+                if (isSpawnFinished)
+                    ApplySpawnPayload(identity, message);
+                else
+                {
+                    // Defer ApplySpawnPayload until OnObjectSpawnFinished
+                    // add to spawned because later when we ApplySpawnPayload
+                    // there may be SyncVars that cross-reference other objects
+                    spawned[message.netId] = identity;
+                    pendingSpawns[identity] = message;
+                }
             }
         }
 

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1303,7 +1303,7 @@ namespace Mirror
             isSpawnFinished = false;
         }
 
-        static Dictionary<NetworkIdentity, SpawnMessage> pendingSpawns = new Dictionary<NetworkIdentity, SpawnMessage>();
+        static readonly Dictionary<NetworkIdentity, SpawnMessage> pendingSpawns = new Dictionary<NetworkIdentity, SpawnMessage>();
 
         internal static void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
         {

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1457,7 +1457,9 @@ namespace Mirror
             if (FindOrSpawnObject(message, out NetworkIdentity identity))
             {
                 if (isSpawnFinished)
+                {
                     ApplySpawnPayload(identity, message);
+                }
                 else
                 {
                     // Defer ApplySpawnPayload until OnObjectSpawnFinished


### PR DESCRIPTION
Virtually eliminates null refs with GO/NI/NB SyncVars by getting all objects into spawned dictionary before applying payloads and invoking hooks.
- No change to normal spawning, only initial spawn
- Uses and clears a static dictionary, so no garbage allocation

See ticket #3097

Test with PickupsDropsChilds example:
- Added SyncList to PickupsDropsChilds on player for everything player drops
- Added SyncVar to SceneObject for owner player object
- Started with built host client, dropped 3 things, then joined client from editor
- Depending on spawn order, either the SyncVar hook or the SyncList OnAdd handler would've thrown NRE's

```cs
public readonly SyncList<GameObject> drops = new SyncList<GameObject>();

public override void OnStartClient()
{
    drops.OnAdd += OnAdd;
    for (int i = 0; i < drops.Count; i++)
        drops.OnAdd?.Invoke(i);
}

void OnAdd(int index)
{
    Debug.Log($"OnAdd {index} {drops[index].name}");
}

[Command]
void CmdDropItem()
{
    . . .
    // set owner object
    sceneObject.owner = gameObject;
    . . .
    // Spawn the scene object on the network for all to see
    NetworkServer.Spawn(newSceneObject);

    drops.Add(newSceneObject);
}
```
```cs
[ReadOnly, SyncVar(hook = nameof(OnOwnerChanged))]
public GameObject owner;

void OnOwnerChanged(GameObject _, GameObject newOwner)
{
    Debug.Log($"SyncVar hook OnOwnerChanged {owner.name}", owner);
}
```
Before this PR
```
NullReferenceException: Object reference not set to an instance of an object
Mirror.Examples.PickupsDropsChilds.PickupsDropsChilds.OnAdd (System.Int32 index) (at Assets/Mirror/Examples/PickupsDropsChilds/Scripts/PickupsDropsChilds.cs:40)
Mirror.Examples.PickupsDropsChilds.PickupsDropsChilds.OnStartClient () (at Assets/Mirror/Examples/PickupsDropsChilds/Scripts/PickupsDropsChilds.cs:35)
Mirror.NetworkIdentity.OnStartClient () (at Assets/Mirror/Core/NetworkIdentity.cs:757)
UnityEngine.Debug:LogException(Exception, Object)
Mirror.NetworkIdentity:OnStartClient() (at Assets/Mirror/Core/NetworkIdentity.cs:761)
Mirror.NetworkClient:InvokeIdentityCallbacks(NetworkIdentity) (at Assets/Mirror/Core/NetworkClient.cs:1398)
Mirror.NetworkClient:BootstrapIdentity(NetworkIdentity) (at Assets/Mirror/Core/NetworkClient.cs:1371)
```
After the PR, all refs are valid.

![image](https://github.com/user-attachments/assets/7d7f8791-ad74-4ad1-b905-689a93de3247)
