### PR TITLE
fix(NetworkServer): Call NetworkClient.InvokeUnSpawnHandler from UnSpawnInternal

### DIFF
--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1720,7 +1720,7 @@ namespace Mirror
             // in host mode, call OnStopClient/OnStopLocalPlayer manually
             if (NetworkClient.active && activeHost)
             {
-                // custom unspawn handler for this prefab (for prefab pools etc.)
+                // fix: #3962 custom unspawn handler for this prefab (for prefab pools etc.)
                 NetworkClient.InvokeUnSpawnHandler(identity.assetId, identity.gameObject);
 
                 if (identity.isLocalPlayer)

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -1720,6 +1720,9 @@ namespace Mirror
             // in host mode, call OnStopClient/OnStopLocalPlayer manually
             if (NetworkClient.active && activeHost)
             {
+                // custom unspawn handler for this prefab (for prefab pools etc.)
+                NetworkClient.InvokeUnSpawnHandler(identity.assetId, identity.gameObject);
+
                 if (identity.isLocalPlayer)
                     identity.OnStopLocalPlayer();
 


### PR DESCRIPTION
- Fixes #3962 

There may be a custom unspawn handler for the prefab and NetworkClient::OnHostClientObjectDestroy doesn't invoke it and can't because it's already out of spawned dictionary.