### PR TITLE
breaking: Move connectionId to NetworkConnectionToClient

### DIFF
--- a/Assets/Mirror/Core/NetworkConnection.cs
+++ b/Assets/Mirror/Core/NetworkConnection.cs
@@ -10,11 +10,6 @@ namespace Mirror
     {
         public const int LocalConnectionId = 0;
 
-        /// <summary>Unique identifier for this connection that is assigned by the transport layer.</summary>
-        // assigned by transport, this id is unique for every connection on server.
-        // clients don't know their own id and they don't know other client's ids.
-        public readonly int connectionId;
-
         /// <summary>Flag that indicates the client has been authenticated.</summary>
         public bool isAuthenticated;
 
@@ -66,11 +61,6 @@ namespace Mirror
             // set lastTime to current time when creating connection to make
             // sure it isn't instantly kicked for inactivity
             lastMessageTime = Time.time;
-        }
-
-        internal NetworkConnection(int networkConnectionId) : this()
-        {
-            connectionId = networkConnectionId;
         }
 
         // TODO if we only have Reliable/Unreliable, then we could initialize
@@ -213,7 +203,5 @@ namespace Mirror
                 batcher.Clear();
             }
         }
-
-        public override string ToString() => $"connection({connectionId})";
     }
 }

--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -16,6 +16,11 @@ namespace Mirror
 
         public virtual string address { get; private set; }
 
+        /// <summary>Unique identifier for this connection that is assigned by the transport layer.</summary>
+        // assigned by transport, this id is unique for every connection on server.
+        // clients don't know their own id and they don't know other client's ids.
+        public readonly int connectionId;
+
         /// <summary>NetworkIdentities that this connection can see</summary>
         // TODO move to server's NetworkConnectionToClient?
         public readonly HashSet<NetworkIdentity> observing = new HashSet<NetworkIdentity>();
@@ -50,9 +55,11 @@ namespace Mirror
         /// <summary>Round trip time (in seconds) that it takes a message to go server->client->server.</summary>
         public double rtt => _rtt.Value;
 
-        public NetworkConnectionToClient(int networkConnectionId, string clientAddress = "localhost")
-            : base(networkConnectionId)
+        internal NetworkConnectionToClient() : base() { }
+
+        public NetworkConnectionToClient(int networkConnectionId, string clientAddress = "localhost") : base()
         {
+            connectionId = networkConnectionId;
             address = clientAddress;
 
             // initialize EMA with 'emaDuration' seconds worth of history.
@@ -64,6 +71,8 @@ namespace Mirror
             // buffer limit should be at least multiplier to have enough in there
             snapshotBufferSizeLimit = Mathf.Max((int)NetworkClient.snapshotSettings.bufferTimeMultiplier, snapshotBufferSizeLimit);
         }
+
+        public override string ToString() => $"connection({connectionId})";
 
         public void OnTimeSnapshot(TimeSnapshot snapshot)
         {

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1213,7 +1213,7 @@ namespace Mirror
         }
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
-        internal void RemoveObserver(NetworkConnection conn)
+        internal void RemoveObserver(NetworkConnectionToClient conn)
         {
             observers.Remove(conn.connectionId);
         }


### PR DESCRIPTION
- Only transports set connectionId
- None of our transports set it on client side (NetworkConnectionToServer)
- Some projects may be referencing NetworkConnection type instead of NetworkConnectionToClient and we can't obsolete connectionId in the base class
- Requires fixing NI::RemoveObserver to correct type