### PR TITLE
Auto use OdinInspector if it's present in the project for 'NetworkBehaviourInspector'

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -7,7 +7,12 @@ namespace Mirror
 {
     [CustomEditor(typeof(NetworkBehaviour), true)]
     [CanEditMultipleObjects]
-    public class NetworkBehaviourInspector : Editor
+    public class NetworkBehaviourInspector : 
+        #if ODIN_INSPECTOR
+        Sirenix.OdinInspector.Editor.OdinEditor
+        #else
+        Editor
+        #endif
     {
         bool syncsAnything;
         SyncObjectCollectionsDrawer syncObjectCollectionsDrawer;


### PR DESCRIPTION
At the [community guides](https://mirror-networking.gitbook.io/docs/community-guides/odin-inspector-support), there is a workaround to an issue with _OdinInspector_.

but this issue can be mitigated with compile symbol that Odin automatic set when included in the project.

This commit simplify this fix with minor changes.