### PR TITLE
feat: Add MirrorRenderPipelineConverter for URP Compatibility

### DIFF
--- a/Assets/Mirror/Examples/Editor.meta
+++ b/Assets/Mirror/Examples/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e52b854d04a1b747b68c5274396cd71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs
+++ b/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs
@@ -2,7 +2,6 @@ using UnityEngine;
 using UnityEditor;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 
 namespace Mirror.Examples.Editor
 {
@@ -18,20 +17,16 @@ namespace Mirror.Examples.Editor
 
         private static void CheckPipelineOnLoad()
         {
-            // Check if already converted
             if (HasConvertedFlag())
                 return;
 
-            // Detect current pipeline
             RenderPipelineType currentPipeline = DetectRenderPipeline();
             if (currentPipeline == RenderPipelineType.BuiltIn)
             {
-                // No conversion needed, silently set flag and exit
                 SetConvertedFlag();
                 return;
             }
 
-            // Get Examples folder path dynamically
             string examplesPath = GetExamplesFolderPath();
             if (string.IsNullOrEmpty(examplesPath))
             {
@@ -39,14 +34,13 @@ namespace Mirror.Examples.Editor
                 return;
             }
 
-            // Show dialog with three options
             int choice = EditorUtility.DisplayDialogComplex(
                 "Mirror Examples Pipeline Conversion",
                 $"Mirror examples need to be converted to {currentPipeline}.\n\nThis will only affect {examplesPath} and subfolders.",
                 "Go Ahead",         // 0 - Left (confirm)
                 "Don't Ask Again",  // 1 - Right (cancel)
                 "Not Now"           // 2 - Middle (alternative)
-);
+            );
 
             switch (choice)
             {
@@ -59,7 +53,6 @@ namespace Mirror.Examples.Editor
                     SetConvertedFlag();
                     break;
                 case 2: // Not Now
-                    // Do nothing
                     break;
             }
         }
@@ -73,39 +66,32 @@ namespace Mirror.Examples.Editor
         private static RenderPipelineType DetectRenderPipeline()
         {
             var pipeline = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline;
-            if (pipeline == null)
-                return RenderPipelineType.BuiltIn;
-
-            if (pipeline.GetType().Name.Contains("Universal"))
-                return RenderPipelineType.URP;
-
-            return RenderPipelineType.BuiltIn; // Default fallback
+            return pipeline != null && pipeline.GetType().Name.Contains("Universal") ? RenderPipelineType.URP : RenderPipelineType.BuiltIn;
         }
 
         private static string GetExamplesFolderPath()
         {
-            // Find this script's path by searching for its type
             string[] guids = AssetDatabase.FindAssets("MirrorRenderPipelineConverter t:Script");
-            if (guids.Length == 0)
-                return null;
-
+            if (guids.Length == 0) return null;
             string scriptPath = AssetDatabase.GUIDToAssetPath(guids[0]);
-            // Go up one level from Editor folder to Examples folder
-            string examplesPath = Path.GetDirectoryName(Path.GetDirectoryName(scriptPath));
-
-            return examplesPath?.Replace("\\", "/"); // Ensure forward slashes for Unity
+            return Path.GetDirectoryName(Path.GetDirectoryName(scriptPath))?.Replace("\\", "/");
         }
 
+        /// <summary>
+        /// Converts materials in the Examples folder to match the current render pipeline.
+        /// Only processes .mat files and forces conversion for legacy/built-in shaders.
+        /// </summary>
         private static void ConvertMaterials(RenderPipelineType targetPipeline, string examplesPath)
         {
             if (!Directory.Exists(examplesPath))
             {
-                Debug.LogError("Examples folder not found at: " + examplesPath);
+                Debug.LogError($"Examples folder not found at: {examplesPath}");
                 return;
             }
 
             try
             {
+                // Find all .mat files in Examples folder and subfolders
                 string[] materialGuids = AssetDatabase.FindAssets("t:Material", new[] { examplesPath })
                     .Where(guid => AssetDatabase.GUIDToAssetPath(guid).EndsWith(".mat"))
                     .ToArray();
@@ -117,22 +103,20 @@ namespace Mirror.Examples.Editor
 
                     if (mat != null)
                     {
-                        // Force conversion for non-URP shaders
                         string shaderName = mat.shader.name;
+                        // Force conversion for non-URP shaders that won't render correctly
                         bool needsConversion = shaderName.StartsWith("Legacy Shaders/") ||
                                               shaderName == "Standard" ||
                                               shaderName == "Standard (Specular setup)";
 
                         if (!needsConversion && Shader.Find(shaderName) != null)
                         {
-                            Debug.Log($"Shader {shaderName} exists and is assumed URP-compatible, skipping: {path}");
+                            Debug.Log($"Shader '{shaderName}' exists and is assumed URP-compatible, skipping: {path}");
                             continue;
                         }
 
                         if (targetPipeline == RenderPipelineType.URP)
-                        {
                             ConvertToURP(mat);
-                        }
                     }
                 }
 
@@ -141,49 +125,50 @@ namespace Mirror.Examples.Editor
             }
             catch (System.Exception e)
             {
-                Debug.LogError("Error during material conversion: " + e.Message);
+                Debug.LogError($"Error during material conversion: {e.Message}");
             }
         }
 
+        /// <summary>
+        /// Converts a material to URP-compatible shaders, preserving properties like color, texture, tiling, and transparency.
+        /// </summary>
         private static void ConvertToURP(Material material)
         {
             string originalShaderName = material.shader.name;
 
-            // Capture initial state before any changes
+            // Capture all relevant properties before changing the shader
             Color initialColor = material.GetColor("_Color");
-            Debug.Log($"Initial _Color for {material.name}: {initialColor} (Hex: {ColorUtility.ToHtmlStringRGBA(initialColor)})");
+            Debug.Log($"Initial _Color for '{material.name}': {initialColor} (Hex: {ColorUtility.ToHtmlStringRGBA(initialColor)})");
 
-            Texture initialMainTex = null;
-            Vector4 initialMainTex_ST = Vector4.zero; // For tiling/offset (x, y = scale; z, w = offset)
+            Texture mainTex = null;
+            Vector4 mainTexST = Vector4.zero; // x, y = tiling; z, w = offset
             if (material.HasProperty("_MainTex"))
             {
-                initialMainTex = material.GetTexture("_MainTex");
-                initialMainTex_ST = material.GetVector("_MainTex_ST"); // Tiling and offset
-                Debug.Log($"Initial _MainTex for {material.name}: {(initialMainTex != null ? initialMainTex.name : "null")}, Tiling/Offset: {initialMainTex_ST}");
+                mainTex = material.GetTexture("_MainTex");
+                mainTexST = material.GetVector("_MainTex_ST");
+                Debug.Log($"Initial _MainTex for '{material.name}': {(mainTex != null ? mainTex.name : "null")}, Tiling/Offset: {mainTexST}");
             }
-            if (initialMainTex == null && material.mainTexture != null)
+            else if (material.mainTexture != null)
             {
-                initialMainTex = material.mainTexture;
-                initialMainTex_ST = new Vector4(material.mainTextureScale.x, material.mainTextureScale.y, material.mainTextureOffset.x, material.mainTextureOffset.y);
-                Debug.Log($"Initial mainTexture fallback for {material.name}: {initialMainTex.name}, Tiling/Offset: {initialMainTex_ST}");
+                mainTex = material.mainTexture;
+                mainTexST = new Vector4(material.mainTextureScale.x, material.mainTextureScale.y, material.mainTextureOffset.x, material.mainTextureOffset.y);
+                Debug.Log($"Initial mainTexture fallback for '{material.name}': {mainTex.name}, Tiling/Offset: {mainTexST}");
             }
 
-            Texture initialBumpMap = null;
+            Texture bumpMap = null;
             if (material.HasProperty("_BumpMap"))
             {
-                initialBumpMap = material.GetTexture("_BumpMap");
-                Debug.Log($"Initial _BumpMap for {material.name}: {(initialBumpMap != null ? initialBumpMap.name : "null")}");
+                bumpMap = material.GetTexture("_BumpMap");
+                Debug.Log($"Initial _BumpMap for '{material.name}': {(bumpMap != null ? bumpMap.name : "null")}");
             }
 
-            float initialMetallic = material.HasProperty("_Metallic") ? material.GetFloat("_Metallic") : 0f;
-            float initialGlossiness = material.HasProperty("_Glossiness") ? material.GetFloat("_Glossiness") : 0.5f;
-            Debug.Log($"Initial Metallic for {material.name}: {initialMetallic}, Glossiness: {initialGlossiness}");
+            float metallic = material.HasProperty("_Metallic") ? material.GetFloat("_Metallic") : 0f;
+            float smoothness = material.HasProperty("_Glossiness") ? material.GetFloat("_Glossiness") : 0.5f;
+            Debug.Log($"Initial Metallic for '{material.name}': {metallic}, Smoothness: {smoothness}");
 
-            // Capture rendering mode (0 = Opaque, 1 = Transparent, etc.)
-            int renderQueue = material.renderQueue;
-            bool isTransparent = renderQueue == (int)UnityEngine.Rendering.RenderQueue.Transparent; // 3000 typically indicates Transparent
+            bool isTransparent = material.renderQueue == (int)UnityEngine.Rendering.RenderQueue.Transparent;
 
-            // Handle skybox conversion
+            // Handle skybox materials
             if (originalShaderName.StartsWith("Skybox/"))
             {
                 if (originalShaderName == "Skybox/6 Sided")
@@ -192,7 +177,7 @@ namespace Mirror.Examples.Editor
                     if (urpSixSidedShader != null && material.shader != urpSixSidedShader)
                     {
                         material.shader = urpSixSidedShader;
-                        Debug.Log($"Updated to URP Skybox/6 Sided: {AssetDatabase.GetAssetPath(material)}");
+                        Debug.Log($"Converted to URP Skybox/6 Sided: {AssetDatabase.GetAssetPath(material)}");
                     }
                     return;
                 }
@@ -214,7 +199,7 @@ namespace Mirror.Examples.Editor
                 }
             }
 
-            // Convert to URP Lit
+            // Convert to URP Lit for all other materials
             Shader urpLitShader = Shader.Find("Universal Render Pipeline/Lit");
             if (urpLitShader == null)
             {
@@ -224,64 +209,56 @@ namespace Mirror.Examples.Editor
 
             material.shader = urpLitShader;
 
-            // Apply captured albedo texture and tiling
-            if (initialMainTex != null)
+            // Apply texture and tiling
+            if (mainTex != null)
             {
-                material.SetTexture("_BaseMap", initialMainTex);
-                material.SetVector("_BaseMap_ST", initialMainTex_ST); // Set tiling and offset
-                Debug.Log($"Set _BaseMap for {material.name} to: {initialMainTex.name}, Tiling/Offset: {initialMainTex_ST}");
+                material.SetTexture("_BaseMap", mainTex);
+                material.SetVector("_BaseMap_ST", mainTexST);
+                Debug.Log($"Set _BaseMap for '{material.name}' to: {mainTex.name}, Tiling/Offset: {mainTexST}");
             }
             else
             {
-                Debug.Log($"No albedo texture found for {material.name} at {AssetDatabase.GetAssetPath(material)}");
+                Debug.Log($"No albedo texture found for '{material.name}' at {AssetDatabase.GetAssetPath(material)}");
             }
 
-            // Apply captured color
-            Color baseColor = initialColor;
-            if (baseColor == Color.clear)
-            {
-                baseColor = material.color != Color.clear ? material.color : Color.white;
-                Debug.Log($"Initial color was clear, using fallback for {material.name}: {baseColor} (Hex: {ColorUtility.ToHtmlStringRGBA(baseColor)})");
-            }
-            else
-            {
-                Debug.Log($"Using initial _Color for {material.name}: {baseColor} (Hex: {ColorUtility.ToHtmlStringRGBA(baseColor)})");
-            }
+            // Apply color
+            Color baseColor = initialColor == Color.clear ? Color.white : initialColor;
             material.SetColor("_BaseColor", baseColor);
+            Debug.Log($"Set _BaseColor for '{material.name}' to: {baseColor} (Hex: {ColorUtility.ToHtmlStringRGBA(baseColor)})");
 
-            // Apply captured normal map
-            if (initialBumpMap != null)
+            // Apply normal map
+            if (bumpMap != null)
             {
-                material.SetTexture("_BumpMap", initialBumpMap);
-                Debug.Log($"Set _BumpMap for {material.name} to: {initialBumpMap.name}");
+                material.SetTexture("_BumpMap", bumpMap);
+                Debug.Log($"Set _BumpMap for '{material.name}' to: {bumpMap.name}");
             }
 
             // Apply metallic and smoothness
-            material.SetFloat("_Metallic", initialMetallic);
-            material.SetFloat("_Smoothness", initialGlossiness);
-            Debug.Log($"Set Metallic for {material.name} to: {initialMetallic}, Smoothness to: {initialGlossiness}");
+            material.SetFloat("_Metallic", metallic);
+            material.SetFloat("_Smoothness", smoothness);
+            Debug.Log($"Set Metallic for '{material.name}' to: {metallic}, Smoothness to: {smoothness}");
 
-            // Apply surface type (rendering mode)
+            // Set surface type and blending
             if (isTransparent)
             {
-                material.SetFloat("_Surface", 1f); // 1 = Transparent
+                material.SetFloat("_Surface", 1f); // Transparent
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                material.SetInt("_ZWrite", 0); // Typically off for transparent
+                material.SetInt("_ZWrite", 0);
                 material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-                Debug.Log($"Set {material.name} to Transparent Surface Type");
+                Debug.Log($"Set '{material.name}' to Transparent Surface Type");
             }
             else
             {
-                material.SetFloat("_Surface", 0f); // 0 = Opaque
+                material.SetFloat("_Surface", 0f); // Opaque
                 material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                 material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
-                material.SetInt("_ZWrite", 1); // Typically on for opaque
+                material.SetInt("_ZWrite", 1);
                 material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
-                Debug.Log($"Set {material.name} to Opaque Surface Type");
+                Debug.Log($"Set '{material.name}' to Opaque Surface Type");
             }
 
-            Debug.Log($"Converted {originalShaderName} to URP Lit: {AssetDatabase.GetAssetPath(material)}");
+            Debug.Log($"Converted '{originalShaderName}' to URP Lit: {AssetDatabase.GetAssetPath(material)}");
         }
 
         private static bool HasConvertedFlag()

--- a/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs
+++ b/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs
@@ -1,0 +1,300 @@
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Mirror.Examples.Editor
+{
+    [InitializeOnLoad]
+    public class MirrorRenderPipelineConverter
+    {
+        private const string CONVERTED_FLAG_FILE = "MirrorExamplesPipelineConverted.txt";
+
+        static MirrorRenderPipelineConverter()
+        {
+            EditorApplication.delayCall += CheckPipelineOnLoad;
+        }
+
+        private static void CheckPipelineOnLoad()
+        {
+            // Check if already converted
+            if (HasConvertedFlag())
+                return;
+
+            // Detect current pipeline
+            RenderPipelineType currentPipeline = DetectRenderPipeline();
+            if (currentPipeline == RenderPipelineType.BuiltIn)
+            {
+                // No conversion needed, silently set flag and exit
+                SetConvertedFlag();
+                return;
+            }
+
+            // Get Examples folder path dynamically
+            string examplesPath = GetExamplesFolderPath();
+            if (string.IsNullOrEmpty(examplesPath))
+            {
+                Debug.LogError("Could not locate Examples folder!");
+                return;
+            }
+
+            // Show dialog with three options
+            int choice = EditorUtility.DisplayDialogComplex(
+                "Mirror Examples Pipeline Conversion",
+                $"Mirror examples need to be converted to {currentPipeline}.\n\nThis will only affect {examplesPath} and subfolders.",
+                "Go Ahead",         // 0 - Left (confirm)
+                "Don't Ask Again",  // 1 - Right (cancel)
+                "Not Now"           // 2 - Middle (alternative)
+);
+
+            switch (choice)
+            {
+                case 0: // Go Ahead
+                    ConvertMaterials(currentPipeline, examplesPath);
+                    SetConvertedFlag();
+                    Debug.Log("Mirror Examples materials converted to " + currentPipeline);
+                    break;
+                case 1: // Don't Ask Again
+                    SetConvertedFlag();
+                    break;
+                case 2: // Not Now
+                    // Do nothing
+                    break;
+            }
+        }
+
+        private enum RenderPipelineType
+        {
+            BuiltIn,
+            URP
+        }
+
+        private static RenderPipelineType DetectRenderPipeline()
+        {
+            var pipeline = UnityEngine.Rendering.GraphicsSettings.currentRenderPipeline;
+            if (pipeline == null)
+                return RenderPipelineType.BuiltIn;
+
+            if (pipeline.GetType().Name.Contains("Universal"))
+                return RenderPipelineType.URP;
+
+            return RenderPipelineType.BuiltIn; // Default fallback
+        }
+
+        private static string GetExamplesFolderPath()
+        {
+            // Find this script's path by searching for its type
+            string[] guids = AssetDatabase.FindAssets("MirrorRenderPipelineConverter t:Script");
+            if (guids.Length == 0)
+                return null;
+
+            string scriptPath = AssetDatabase.GUIDToAssetPath(guids[0]);
+            // Go up one level from Editor folder to Examples folder
+            string examplesPath = Path.GetDirectoryName(Path.GetDirectoryName(scriptPath));
+
+            return examplesPath?.Replace("\\", "/"); // Ensure forward slashes for Unity
+        }
+
+        private static void ConvertMaterials(RenderPipelineType targetPipeline, string examplesPath)
+        {
+            if (!Directory.Exists(examplesPath))
+            {
+                Debug.LogError("Examples folder not found at: " + examplesPath);
+                return;
+            }
+
+            try
+            {
+                string[] materialGuids = AssetDatabase.FindAssets("t:Material", new[] { examplesPath })
+                    .Where(guid => AssetDatabase.GUIDToAssetPath(guid).EndsWith(".mat"))
+                    .ToArray();
+
+                foreach (string guid in materialGuids)
+                {
+                    string path = AssetDatabase.GUIDToAssetPath(guid);
+                    Material mat = AssetDatabase.LoadAssetAtPath<Material>(path);
+
+                    if (mat != null)
+                    {
+                        // Force conversion for non-URP shaders
+                        string shaderName = mat.shader.name;
+                        bool needsConversion = shaderName.StartsWith("Legacy Shaders/") ||
+                                              shaderName == "Standard" ||
+                                              shaderName == "Standard (Specular setup)";
+
+                        if (!needsConversion && Shader.Find(shaderName) != null)
+                        {
+                            Debug.Log($"Shader {shaderName} exists and is assumed URP-compatible, skipping: {path}");
+                            continue;
+                        }
+
+                        if (targetPipeline == RenderPipelineType.URP)
+                        {
+                            ConvertToURP(mat);
+                        }
+                    }
+                }
+
+                AssetDatabase.SaveAssets();
+                AssetDatabase.Refresh();
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogError("Error during material conversion: " + e.Message);
+            }
+        }
+
+        private static void ConvertToURP(Material material)
+        {
+            string originalShaderName = material.shader.name;
+
+            // Capture initial state before any changes
+            Color initialColor = material.GetColor("_Color");
+            Debug.Log($"Initial _Color for {material.name}: {initialColor} (Hex: {ColorUtility.ToHtmlStringRGBA(initialColor)})");
+
+            Texture initialMainTex = null;
+            Vector4 initialMainTex_ST = Vector4.zero; // For tiling/offset (x, y = scale; z, w = offset)
+            if (material.HasProperty("_MainTex"))
+            {
+                initialMainTex = material.GetTexture("_MainTex");
+                initialMainTex_ST = material.GetVector("_MainTex_ST"); // Tiling and offset
+                Debug.Log($"Initial _MainTex for {material.name}: {(initialMainTex != null ? initialMainTex.name : "null")}, Tiling/Offset: {initialMainTex_ST}");
+            }
+            if (initialMainTex == null && material.mainTexture != null)
+            {
+                initialMainTex = material.mainTexture;
+                initialMainTex_ST = new Vector4(material.mainTextureScale.x, material.mainTextureScale.y, material.mainTextureOffset.x, material.mainTextureOffset.y);
+                Debug.Log($"Initial mainTexture fallback for {material.name}: {initialMainTex.name}, Tiling/Offset: {initialMainTex_ST}");
+            }
+
+            Texture initialBumpMap = null;
+            if (material.HasProperty("_BumpMap"))
+            {
+                initialBumpMap = material.GetTexture("_BumpMap");
+                Debug.Log($"Initial _BumpMap for {material.name}: {(initialBumpMap != null ? initialBumpMap.name : "null")}");
+            }
+
+            float initialMetallic = material.HasProperty("_Metallic") ? material.GetFloat("_Metallic") : 0f;
+            float initialGlossiness = material.HasProperty("_Glossiness") ? material.GetFloat("_Glossiness") : 0.5f;
+            Debug.Log($"Initial Metallic for {material.name}: {initialMetallic}, Glossiness: {initialGlossiness}");
+
+            // Capture rendering mode (0 = Opaque, 1 = Transparent, etc.)
+            int renderQueue = material.renderQueue;
+            bool isTransparent = renderQueue == (int)UnityEngine.Rendering.RenderQueue.Transparent; // 3000 typically indicates Transparent
+
+            // Handle skybox conversion
+            if (originalShaderName.StartsWith("Skybox/"))
+            {
+                if (originalShaderName == "Skybox/6 Sided")
+                {
+                    Shader urpSixSidedShader = Shader.Find("Skybox/6 Sided");
+                    if (urpSixSidedShader != null && material.shader != urpSixSidedShader)
+                    {
+                        material.shader = urpSixSidedShader;
+                        Debug.Log($"Updated to URP Skybox/6 Sided: {AssetDatabase.GetAssetPath(material)}");
+                    }
+                    return;
+                }
+                else
+                {
+                    Shader urpSkyboxShader = Shader.Find("Skybox/Panoramic");
+                    if (urpSkyboxShader != null && material.shader != urpSkyboxShader)
+                    {
+                        material.shader = urpSkyboxShader;
+                        if (material.HasProperty("_Tex"))
+                            material.SetTexture("_MainTex", material.GetTexture("_Tex"));
+                        else if (material.HasProperty("_FrontTex"))
+                            material.SetTexture("_MainTex", material.GetTexture("_FrontTex"));
+                        if (material.HasProperty("_Tint"))
+                            material.SetColor("_Tint", material.GetColor("_Tint"));
+                        Debug.Log($"Converted to URP Skybox/Panoramic: {AssetDatabase.GetAssetPath(material)}");
+                    }
+                    return;
+                }
+            }
+
+            // Convert to URP Lit
+            Shader urpLitShader = Shader.Find("Universal Render Pipeline/Lit");
+            if (urpLitShader == null)
+            {
+                Debug.LogError("URP Lit shader not found in project!");
+                return;
+            }
+
+            material.shader = urpLitShader;
+
+            // Apply captured albedo texture and tiling
+            if (initialMainTex != null)
+            {
+                material.SetTexture("_BaseMap", initialMainTex);
+                material.SetVector("_BaseMap_ST", initialMainTex_ST); // Set tiling and offset
+                Debug.Log($"Set _BaseMap for {material.name} to: {initialMainTex.name}, Tiling/Offset: {initialMainTex_ST}");
+            }
+            else
+            {
+                Debug.Log($"No albedo texture found for {material.name} at {AssetDatabase.GetAssetPath(material)}");
+            }
+
+            // Apply captured color
+            Color baseColor = initialColor;
+            if (baseColor == Color.clear)
+            {
+                baseColor = material.color != Color.clear ? material.color : Color.white;
+                Debug.Log($"Initial color was clear, using fallback for {material.name}: {baseColor} (Hex: {ColorUtility.ToHtmlStringRGBA(baseColor)})");
+            }
+            else
+            {
+                Debug.Log($"Using initial _Color for {material.name}: {baseColor} (Hex: {ColorUtility.ToHtmlStringRGBA(baseColor)})");
+            }
+            material.SetColor("_BaseColor", baseColor);
+
+            // Apply captured normal map
+            if (initialBumpMap != null)
+            {
+                material.SetTexture("_BumpMap", initialBumpMap);
+                Debug.Log($"Set _BumpMap for {material.name} to: {initialBumpMap.name}");
+            }
+
+            // Apply metallic and smoothness
+            material.SetFloat("_Metallic", initialMetallic);
+            material.SetFloat("_Smoothness", initialGlossiness);
+            Debug.Log($"Set Metallic for {material.name} to: {initialMetallic}, Smoothness to: {initialGlossiness}");
+
+            // Apply surface type (rendering mode)
+            if (isTransparent)
+            {
+                material.SetFloat("_Surface", 1f); // 1 = Transparent
+                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+                material.SetInt("_ZWrite", 0); // Typically off for transparent
+                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                Debug.Log($"Set {material.name} to Transparent Surface Type");
+            }
+            else
+            {
+                material.SetFloat("_Surface", 0f); // 0 = Opaque
+                material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+                material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
+                material.SetInt("_ZWrite", 1); // Typically on for opaque
+                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
+                Debug.Log($"Set {material.name} to Opaque Surface Type");
+            }
+
+            Debug.Log($"Converted {originalShaderName} to URP Lit: {AssetDatabase.GetAssetPath(material)}");
+        }
+
+        private static bool HasConvertedFlag()
+        {
+            string flagPath = Path.Combine(Application.dataPath, "..", CONVERTED_FLAG_FILE);
+            return File.Exists(flagPath);
+        }
+
+        private static void SetConvertedFlag()
+        {
+            string flagPath = Path.Combine(Application.dataPath, "..", CONVERTED_FLAG_FILE);
+            File.WriteAllText(flagPath, "Converted: " + System.DateTime.Now.ToString());
+            AssetDatabase.Refresh();
+        }
+    }
+}

--- a/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs.meta
+++ b/Assets/Mirror/Examples/Editor/MirrorRenderPipelineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b86c03b3e3faa24ca5391f2f60427fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/454312db-3f6c-499a-912c-d204315b166b)

## Overview
This pull request introduces `MirrorRenderPipelineConverter`, an editor script that automatically converts materials in the `Assets/Mirror/Examples` folder from Unity’s built-in render pipeline (e.g., `Standard`, `Legacy Shaders`) to the Universal Render Pipeline (URP) in Unity 6000+. It ensures Mirror Networking’s example scenes remain visually consistent and functional in modern URP projects, addressing the shift from the default built-in pipeline (Unity 2019) to URP in Unity 6000.

## Key Features
- **Automatic Conversion**: Runs on project load, detects URP, and prompts with options: “Go Ahead” (convert), “Not Now” (skip), or “Don’t Ask Again” (set flag without converting).
- **Targeted Scope**: Only processes `.mat` files within `Assets/Mirror/Examples` and subfolders, preserving user project assets.
- **Property Preservation**: Transfers critical material properties:
  - Albedo color (`_Color` to `_BaseColor`)
  - Texture and tiling (`_MainTex` to `_BaseMap`, including `_MainTex_ST`)
  - Normal maps (`_BumpMap`)
  - Metallic and smoothness (`_Metallic`, `_Glossiness` to `_Smoothness`)
  - Transparency (render queue to `_Surface`)
  - Forward rendering options (`_SpecularHighlights`, `_GlossyReflections` to `_EnvironmentReflections`)
- **Shader Handling**: Forces conversion of incompatible shaders (`Standard`, `Legacy Shaders/*`) to `URP/Lit`, skips URP-compatible shaders (e.g., `Skybox/6 Sided`).
- **Debugging Support**: Extensive logging with clickable material references in the Console.

## Motivation
Starting with Unity 6000, the built-in render pipeline is optional, and URP is the default. Without conversion, Mirror’s example materials (built for Unity 2019’s built-in pipeline) appear pink or incorrect in URP projects due to shader incompatibility. This script eliminates manual updates, ensuring a seamless experience for users upgrading to Unity 6000+.

## Implementation Details
- **Trigger**: Uses `[InitializeOnLoad]` to check on project open, with a flag file (`MirrorExamplesPipelineConverted.txt`) to prevent re-prompting.
- **Path Detection**: Dynamically finds the Examples folder relative to the script’s location, accommodating user folder rearrangements.
- **Robustness**: Wraps conversion in a try-catch block, filters for `.mat` files, and validates shader availability.
- **User Choice**: Dialog respects user intent, with button order adjusted for intuitive UX (Go Ahead = left, Don’t Ask Again = right, Not Now = middle).

## Impact
- **User Experience**: Examples work out of the box in URP, avoiding pink materials or manual fixes.
- **Maintainability**: Clear comments and logs simplify future tweaks or debugging.
- **Compatibility**: Supports Unity 6000+ URP projects while respecting built-in pipeline users.

## Testing
- Validated in a fresh Unity 6000 URP 3D project with iterative imports:
  - Confirmed preservation of color, texture, tiling, transparency, and rendering options (e.g., `Ground.mat`, `Robot_Color`, `Portal`).
  - Verified settings like shininess by matching original `_GlossyReflections` and `_SpecularHighlights` settings.
- Logs provide material-specific feedback for verification.