### PR TITLE
perf: Update NetworkTransformBase default syncInterval.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -438,6 +438,9 @@ namespace Mirror
             ResetState();
             // default to ClientToServer so this works immediately for users
             syncDirection = SyncDirection.ClientToServer;
+
+            // default to 20Hz, 20 sends per second if data has changed.
+            syncInterval = 0.05f;
         }
 
         protected virtual void OnEnable()


### PR DESCRIPTION
Effects both NetworkTransformUnreliable and NetworkRigidbodyUnreliable, when a new component is added, it will use the default, does not effect currently placed components.

If a user increases send rate, needing the boost to framerate, but not wanting to increase sends from the components, previously may unexpectedly be sending more data than intended if they left component intervals at default 0, this helps separate NetworkManager SendRate/FrameRate and the components send intervals to prevent such a case.

Kudos to the Gadget Man.