### PR TITLE
feat: Bool to skip password and auth check in RemoteStatistics.cs

### DIFF
--- a/Assets/Mirror/Components/RemoteStatistics.cs
+++ b/Assets/Mirror/Components/RemoteStatistics.cs
@@ -99,7 +99,8 @@ namespace Mirror
         // this is not perfectly secure. that's why RemoteStatistics is read-only.
         [Header("Authentication")]
         public string passwordFile = "remote_statistics.txt";
-        public bool skipPasswordAuth = false; // allow clients access to statistics by skipping password input and checks
+        [Tooltip("Set to false to skip password input and authentication on client and server.")]
+        public bool requiresPasswordAuth = true; // false to skip password input and checks
         protected bool         serverAuthenticated;   // client needs to authenticate
         protected bool         clientAuthenticated;   // show GUI until authenticated
         protected string       serverPassword = null; // null means not found, auth impossible
@@ -147,8 +148,9 @@ namespace Mirror
             NetworkStatistics = NetworkManager.singleton.GetComponent<NetworkStatistics>();
             if (NetworkStatistics == null) throw new Exception($"RemoteStatistics requires a NetworkStatistics component on {NetworkManager.singleton.name}!");
 
-            if (skipPasswordAuth)
+            if (!requiresPasswordAuth)
             {
+                // auto authenticate if requiring password is false
                 serverAuthenticated = true;
             }
             else
@@ -164,8 +166,9 @@ namespace Mirror
             windowRect.x = Screen.width  / 2 - windowRect.width  / 2;
             windowRect.y = Screen.height / 2 - windowRect.height / 2;
 
-            if (skipPasswordAuth)
+            if (!requiresPasswordAuth)
             {
+                // auto authenticate if requiring password is false
                 clientAuthenticated = true;
             }
         }

--- a/Assets/Mirror/Components/RemoteStatistics.cs
+++ b/Assets/Mirror/Components/RemoteStatistics.cs
@@ -99,6 +99,7 @@ namespace Mirror
         // this is not perfectly secure. that's why RemoteStatistics is read-only.
         [Header("Authentication")]
         public string passwordFile = "remote_statistics.txt";
+        public bool skipPasswordAuth = false; // allow clients access to statistics by skipping password input and checks
         protected bool         serverAuthenticated;   // client needs to authenticate
         protected bool         clientAuthenticated;   // show GUI until authenticated
         protected string       serverPassword = null; // null means not found, auth impossible
@@ -146,8 +147,15 @@ namespace Mirror
             NetworkStatistics = NetworkManager.singleton.GetComponent<NetworkStatistics>();
             if (NetworkStatistics == null) throw new Exception($"RemoteStatistics requires a NetworkStatistics component on {NetworkManager.singleton.name}!");
 
-            // server needs to load the password
-            LoadPassword();
+            if (skipPasswordAuth)
+            {
+                serverAuthenticated = true;
+            }
+            else
+            {
+                // server needs to load the password
+                LoadPassword();
+            }
         }
 
         public override void OnStartLocalPlayer()
@@ -155,6 +163,11 @@ namespace Mirror
             // center the window initially
             windowRect.x = Screen.width  / 2 - windowRect.width  / 2;
             windowRect.y = Screen.height / 2 - windowRect.height / 2;
+
+            if (skipPasswordAuth)
+            {
+                clientAuthenticated = true;
+            }
         }
 
         [TargetRpc]


### PR DESCRIPTION
Allows for quicker testing of remote statistics, or when clients viewing the data is just not a threat.
It is false by default.

<img width="394" alt="Screenshot 2025-03-23 at 10 14 35" src="https://github.com/user-attachments/assets/18c93d1b-bb58-4a87-8bdc-44835ef7d2cb" />
