### PR TITLE
fix(NTHybrid): initial child sync (#4004)

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
@@ -235,13 +235,10 @@ namespace Mirror
 
 
                 if (syncPosition) writer.WriteVector3(snapshot.position);
-                if (syncRotation)
-                {
-                    // note: smallest-three compression sends absolute values.
-                    // technically it doesn't need a baseline, but we still need to sync the initial spawn rotation.
-                    // in other words: alwyas sync the initial rotation as full quaternion.
-                    writer.WriteQuaternion(snapshot.rotation);
-                }
+                // note: smallest-three compression sends absolute values.
+                // technically it doesn't need a baseline, but we still need to sync the initial spawn rotation.
+                // in other words: alwyas sync the initial rotation as full quaternion.
+                if (syncRotation) writer.WriteQuaternion(snapshot.rotation);
                 if (syncScale) writer.WriteVector3(snapshot.scale);
 
                 // save serialized as 'last' for next delta compression.
@@ -307,10 +304,7 @@ namespace Mirror
 
                     if (debugDraw) Debug.DrawLine(position.Value, position.Value + Vector3.up , Color.green, 10.0f);
                 }
-                if (syncRotation)
-                {
-                    rotation = reader.ReadQuaternion();
-                }
+                if (syncRotation) rotation = reader.ReadQuaternion();
                 if (syncScale) scale = reader.ReadVector3();
 
                 // save deserialized as 'last' for next delta compression.

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
@@ -318,6 +318,12 @@ namespace Mirror
                 if (syncPosition) Compression.ScaleToLong(position.Value, positionPrecision, out lastDeserializedPosition);
                 if (syncRotation && !compressRotation) Compression.ScaleToLong(rotation.Value, rotationPrecision, out lastDeserializedRotation);
                 if (syncScale) Compression.ScaleToLong(scale.Value, scalePrecision, out lastDeserializedScale);
+
+                // apply initial values.
+                // Mirror already syncs spawn position, but NT has a 'target' (i.e. child object)
+                // who's initial position we need to set as well.
+                if (isServer) OnClientToServerSync(position, rotation, scale);
+                else if (isClient) OnServerToClientSync(position, rotation, scale);
             }
             // unreliable delta: decompress against last full reliable state
             else

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformHybrid.cs
@@ -233,16 +233,14 @@ namespace Mirror
 
                 int startPosition = writer.Position;
 
+
                 if (syncPosition) writer.WriteVector3(snapshot.position);
                 if (syncRotation)
                 {
-                    // if smallest-three quaternion compression is enabled,
-                    // then we don't need baseline rotation since delta always
-                    // sends an absolute value.
-                    if (!compressRotation)
-                    {
-                        writer.WriteQuaternion(snapshot.rotation);
-                    }
+                    // note: smallest-three compression sends absolute values.
+                    // technically it doesn't need a baseline, but we still need to sync the initial spawn rotation.
+                    // in other words: alwyas sync the initial rotation as full quaternion.
+                    writer.WriteQuaternion(snapshot.rotation);
                 }
                 if (syncScale) writer.WriteVector3(snapshot.scale);
 
@@ -311,13 +309,7 @@ namespace Mirror
                 }
                 if (syncRotation)
                 {
-                    // if smallest-three quaternion compression is enabled,
-                    // then we don't need baseline rotation since delta always
-                    // sends an absolute value.
-                    if (!compressRotation)
-                    {
-                        rotation = reader.ReadQuaternion();
-                    }
+                    rotation = reader.ReadQuaternion();
                 }
                 if (syncScale) scale = reader.ReadVector3();
 


### PR DESCRIPTION
MERGE, NOT SQUASH

Fixes #4004 