### PR TITLE
perf: Streamline DestroyOwnedObjects

### DIFF
--- a/Assets/Mirror/Core/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Core/NetworkConnectionToClient.cs
@@ -217,7 +217,7 @@ namespace Mirror
                 {
                     // disown scene objects, destroy instantiated objects.
                     if (netIdentity.sceneId != 0)
-                        NetworkServer.RemovePlayerForConnection(this, RemovePlayerOptions.KeepActive);
+                        identity.RemoveClientOwner();
                     else
                         NetworkServer.Destroy(netIdentity.gameObject);
                 }

--- a/Assets/Mirror/Core/NetworkIdentity.cs
+++ b/Assets/Mirror/Core/NetworkIdentity.cs
@@ -1575,6 +1575,18 @@ namespace Mirror
             connectionToClient = conn;
         }
 
+        // Do not merge with RemoveClientAuthority
+        // This is called from NetworkConnectionToClient::DestroyOwnedObjects
+        // when a player disconnects to quietly remove ownerhip of scene objects
+        internal void RemoveClientOwner()
+        {
+            if (connectionToClient != null)
+            {
+                clientAuthorityCallback?.Invoke(connectionToClient, this, false);
+                connectionToClient = null;
+            }
+        }
+
         /// <summary>Removes ownership for an object.</summary>
         // Applies to objects that had authority set by AssignClientAuthority,
         // or NetworkServer.Spawn with a NetworkConnection parameter included.
@@ -1595,9 +1607,8 @@ namespace Mirror
 
             if (connectionToClient != null)
             {
-                clientAuthorityCallback?.Invoke(connectionToClient, this, false);
                 NetworkConnectionToClient previousOwner = connectionToClient;
-                connectionToClient = null;
+                RemoveClientOwner();
                 NetworkServer.SendChangeOwnerMessage(this, previousOwner);
             }
         }


### PR DESCRIPTION
- Adds quiet RemoveClientOwner to NetworkIdentity
- Avoids unnecessary SendChangeOwnerMessage that goes nowhere