### PR TITLE
fix(NetworkBehaviourInspector): Hide SyncMethod for NT

### DIFF
--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -95,10 +95,10 @@ namespace Mirror
             if (syncDirection.enumValueIndex == (int)SyncDirection.ServerToClient)
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
 
-            SerializedProperty syncMethod = serializedObject.FindProperty("syncMethod");
             // sync method: Don't show for NT-based components
             if (!typeof(NetworkTransformBase).IsAssignableFrom(scriptClass))
             {
+                SerializedProperty syncMethod = serializedObject.FindProperty("syncMethod");
                 EditorGUILayout.PropertyField(syncMethod);
 
                 // Hybrid sync method: show a warning!

--- a/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
+++ b/Assets/Mirror/Editor/NetworkBehaviourInspector.cs
@@ -9,11 +9,12 @@ namespace Mirror
     [CanEditMultipleObjects]
     public class NetworkBehaviourInspector : Editor
     {
+        Type scriptClass;
         bool syncsAnything;
         SyncObjectCollectionsDrawer syncObjectCollectionsDrawer;
 
         // does this type sync anything? otherwise we don't need to show syncInterval
-        bool SyncsAnything(Type scriptClass)
+        bool SyncsAnything()
         {
             // check for all SyncVar fields, they don't have to be visible
             foreach (FieldInfo field in InspectorHelper.GetAllFields(scriptClass, typeof(NetworkBehaviour)))
@@ -50,11 +51,11 @@ namespace Mirror
             // then Unity temporarily keep using this Inspector causing things to break
             if (!(target is NetworkBehaviour)) { return; }
 
-            Type scriptClass = target.GetType();
+            scriptClass = target.GetType();
 
             syncObjectCollectionsDrawer = new SyncObjectCollectionsDrawer(serializedObject.targetObject);
 
-            syncsAnything = SyncsAnything(scriptClass);
+            syncsAnything = SyncsAnything();
         }
 
         public override void OnInspectorGUI()
@@ -94,14 +95,15 @@ namespace Mirror
             if (syncDirection.enumValueIndex == (int)SyncDirection.ServerToClient)
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("syncMode"));
 
-            // sync method
             SerializedProperty syncMethod = serializedObject.FindProperty("syncMethod");
-            EditorGUILayout.PropertyField(syncMethod);
-
-            // Unreliable sync method: show a warning!
-            if (syncMethod.enumValueIndex == (int)SyncMethod.Hybrid)
+            // sync method: Don't show for NT-based components
+            if (!typeof(NetworkTransformBase).IsAssignableFrom(scriptClass))
             {
-                EditorGUILayout.HelpBox("Beware! Hybrid is experimental!\n- Do not use this in production yet!\n- Doesn't support [SyncVars] yet!\n- You need to use OnDe/Serialize manually!", MessageType.Warning);
+                EditorGUILayout.PropertyField(syncMethod);
+
+                // Hybrid sync method: show a warning!
+                if (syncMethod.enumValueIndex == (int)SyncMethod.Hybrid)
+                    EditorGUILayout.HelpBox("Beware! Hybrid is experimental!\n- Do not use this in production yet!\n- Doesn't support [SyncVars] yet!\n- You need to use OnDe/Serialize manually!", MessageType.Warning);
             }
 
             // sync interval


### PR DESCRIPTION
NetworkTransform components are locked to a certain SyncMethod