### PR TITLE
Add boolean to optionally keep the Network Manager in DDOL

### DIFF
--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -28,6 +28,10 @@ namespace Mirror
         [Tooltip("Multiplayer games should always run in the background so the network doesn't time out.")]
         public bool runInBackground = true;
 
+        /// <summary>If Mirror shall keep the same Network Manager on disconnect, and not make a new one.</summary>
+        Tooltip("If Mirror shall keep the same Network Manager on disconnect, and not make a new one.")]
+        public bool keepOnDisconnect = false; //comment for mirror devs (may delete): set to false by default to not break compatibility for other people.
+
         [Header("Auto-Start Options")]
 
         /// <summary>Should the server auto-start when 'Server Build' is checked in build settings</summary>
@@ -602,11 +606,14 @@ namespace Mirror
             // to avoid collision and let a fresh Network Manager be created.
             // IMPORTANT: .gameObject can be null if StopClient is called from
             //            OnApplicationQuit or from tests!
-            if (gameObject != null
+            if (!keepOnDisconnect)
+            {
+                if (gameObject != null
                 && gameObject.scene.name == "DontDestroyOnLoad"
                 && !string.IsNullOrWhiteSpace(offlineScene)
                 && SceneManager.GetActiveScene().path != offlineScene)
                 SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
+            }
 
             OnStopServer();
 
@@ -1296,11 +1303,14 @@ namespace Mirror
             // to avoid collision and let a fresh Network Manager be created.
             // IMPORTANT: .gameObject can be null if StopClient is called from
             //            OnApplicationQuit or from tests!
-            if (gameObject != null
+            if (!keepOnDisconnect)
+            {
+                if (gameObject != null
                 && gameObject.scene.name == "DontDestroyOnLoad"
                 && !string.IsNullOrWhiteSpace(offlineScene)
                 && SceneManager.GetActiveScene().path != offlineScene)
                 SceneManager.MoveGameObjectToScene(gameObject, SceneManager.GetActiveScene());
+            }
 
             // If StopHost called in Host mode, StopServer will change scenes after this.
             // Check loadingSceneAsync to ensure we don't double-invoke the scene change.


### PR DESCRIPTION
Especially for EOSTransport, without this, it breaks the login sequence. When you are in a lobby, you're logged in, but when you disconnect, the current Network Manager is moved out of DDOL. And because you are loading into the main menu, it creates a brand new one and deletes the current one, which breaks all sorts of things in the EOS SDK.

I have added:
- A boolean to optionally disable the code that moves the Network Manager out of Don't Destroy On Load.

Please feel free to add or change anything! I have done testing in my own game, it works just fine with v96.2.2. Thank you!