### PR TITLE
fix: Reset exceptionsDisconnect in Shutdown

### DIFF
--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -1991,6 +1991,8 @@ namespace Mirror
             isLoadingScene = false;
             lastSendTime = 0;
 
+            exceptionsDisconnect = true;
+
             unbatcher = new Unbatcher();
 
             // clear events. someone might have hooked into them before, but

--- a/Assets/Mirror/Core/NetworkServer.cs
+++ b/Assets/Mirror/Core/NetworkServer.cs
@@ -264,6 +264,8 @@ namespace Mirror
             lastSendTime = 0;
             actualTickRate = 0;
 
+            exceptionsDisconnect = true;
+
             localConnection = null;
 
             connections.Clear();

--- a/Assets/Mirror/Tests/Editor/NetworkClient/NetworkClientTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkClient/NetworkClientTests.cs
@@ -143,6 +143,8 @@ namespace Mirror.Tests.NetworkClients
             Assert.That(NetworkClient.isSpawnFinished, Is.False);
             Assert.That(NetworkClient.isLoadingScene, Is.False);
 
+            Assert.That(NetworkClient.exceptionsDisconnect, Is.True);
+
             Assert.That(NetworkClient.OnConnectedEvent, Is.Null);
             Assert.That(NetworkClient.OnDisconnectedEvent, Is.Null);
             Assert.That(NetworkClient.OnErrorEvent, Is.Null);

--- a/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkServer/NetworkServerTest.cs
@@ -1172,10 +1172,14 @@ namespace Mirror.Tests.NetworkServers
             Assert.That(NetworkServer.active, Is.False);
             Assert.That(NetworkServer.isLoadingScene, Is.False);
 
+            Assert.That(NetworkServer.exceptionsDisconnect, Is.True);
+
             Assert.That(NetworkServer.connections.Count, Is.EqualTo(0));
             Assert.That(NetworkServer.connectionsCopy.Count, Is.EqualTo(0));
             Assert.That(NetworkServer.handlers.Count, Is.EqualTo(0));
             Assert.That(NetworkServer.spawned.Count, Is.EqualTo(0));
+
+            Assert.That(NetworkServer.actualTickRate, Is.EqualTo(0));
 
             Assert.That(NetworkServer.localConnection, Is.Null);
             Assert.That(NetworkServer.activeHost, Is.False);


### PR DESCRIPTION
Applies to both NetworkServer and NetworkClient
Tests updated too