### PR TITLE
Updated PredictedRigidbody so that it doesn't reset the ghost objects transforms to inital position and rotation.

### DIFF
--- a/Assets/Mirror/Components/PredictedRigidbody/PredictedRigidbody.cs
+++ b/Assets/Mirror/Components/PredictedRigidbody/PredictedRigidbody.cs
@@ -214,9 +214,9 @@ namespace Mirror
             Vector3 position = tf.position;
             Quaternion rotation = tf.rotation;
             // Vector3 scale = tf.localScale; // don't change scale for now. causes issues with parenting.
-            // => reset to initial
-            physicsGhostRigidbody.transform.position = tf.position = initialPosition;
-            physicsGhostRigidbody.transform.rotation = tf.rotation = initialRotation;
+            // Instead of setting to the initial position we can set to the transform position this prevents teleporting and correction when the ghosts are created.
+            physicsGhostRigidbody.transform.position = tf.position;// = initialPosition;
+            physicsGhostRigidbody.transform.rotation = tf.rotation;// = initialRotation;
             physicsGhostRigidbody.transform.localScale = tf.lossyScale;// world scale! // = initialScale; // don't change scale for now. causes issues with parenting.
             // => move physics components
             PredictionUtils.MovePhysicsComponents(gameObject, physicsCopy);
@@ -269,9 +269,9 @@ namespace Mirror
                 Vector3 position = tf.position;
                 Quaternion rotation = tf.rotation;
                 Vector3 scale = tf.localScale;
-                // => reset to initial
-                physicsCopy.transform.position = tf.position = initialPosition;
-                physicsCopy.transform.rotation = tf.rotation = initialRotation;
+                // Instead of setting to the initial position we can set to the transform position this prevents teleporting and correction when the ghosts are destroyed.
+                physicsCopy.transform.position = tf.position;// = initialPosition;
+                physicsCopy.transform.rotation = tf.rotation;// = initialRotation;
                 physicsCopy.transform.localScale = tf.lossyScale;// = initialScale;
                 // => move physics components
                 PredictionUtils.MovePhysicsComponents(physicsCopy, gameObject);


### PR DESCRIPTION
I am developing a physics based game and noticed that when the ghost objects are created and destroyed the object would visually teleport to a position and then get corrected back to where they should be. I noticed in the code where ghosts are created and destroyed the copy was being set back to the initial position and rotation this created weird behavior in my game because the objects were moved quite far from the initial position and rotation by now. 

I commented out the logic of setting the ghosts to the initial position and rotation and it seemed to have fixed the teleporting issue I was facing and now the objects move smoothly on the client. However, I am not sure why this logic was here in the first place if it was put in place to prevent other issues, and if removing it will cause any unwanted behavior for other use cases.

I mentioned this in the Discord server and was told to make a pull request so we could discuss the changes I made here.