### PR TITLE
Add 6000 / 6000.1 LTS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _The top quote is from Fitzcarraldo, which is quite reminiscent of this project.
 
 ---
 ## Getting Started
-Get **Unity 2019 / 2020 / 2021 / 2022 LTS**, [Download Mirror](https://assetstore.unity.com/packages/tools/network/mirror-129321), open one of the examples & press Play!
+Get **Unity 2019 / 2020 / 2021 / 2022 / 6000 / 6000.1 LTS**, [Download Mirror](https://assetstore.unity.com/packages/tools/network/mirror-129321), open one of the examples & press Play!
 
 Check out our [Documentation](https://mirror-networking.gitbook.io/) to learn how it all works.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ _The top quote is from Fitzcarraldo, which is quite reminiscent of this project.
 
 ---
 ## Getting Started
-Get **Unity 2019 / 2020 / 2021 / 2022 / 6000 / 6000.1 LTS**, [Download Mirror](https://assetstore.unity.com/packages/tools/network/mirror-129321), open one of the examples & press Play!
+Get **Unity 2019 / 2020 / 2021 / 2022 LTS and 6000.1**, [Download Mirror](https://assetstore.unity.com/packages/tools/network/mirror-129321), open one of the examples & press Play!
 
 Check out our [Documentation](https://mirror-networking.gitbook.io/) to learn how it all works.
 


### PR DESCRIPTION
Adds the 6 and 6.1 LTSs to the README file. I was going to remove 2019 and 2020 since Unity no longer supports them, but I want to check in with you guys before doing it. Also, 6.1 is "supported", not LTS, so if you want to remove it as well, you may.