### PR TITLE
Update Transports List

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Mirror uses **KCP** (reliable UDP) by default, but you may use any of our commun
 * [LiteNetLib](https://github.com/MirrorNetworking/LiteNetLibTransport/) UDP
 * [FizzySteam](https://github.com/Chykary/FizzySteamworks/): SteamNetwork
 * [FizzyFacepunch](https://github.com/Chykary/FizzyFacepunch/): SteamNetwork
-* [Epic Relay](https://github.com/FakeByte/EpicOnlineTransport): Epic Online Services
+* [Epic Relay](https://github.com/WeLoveJesusChrist/EOSTransport): Epic Online Services
 * [Bubble](https://github.com/Squaresweets/BubbleTransport): Apple GameCenter
 * [Light Reflective Mirror](https://github.com/Derek-R-S/Light-Reflective-Mirror): Self-Hosted Relay
 * [Oculus P2P](https://github.com/hyferg/MirrorOculusP2P): Oculus Platform Service

--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ Mirror uses **KCP** (reliable UDP) by default, but you may use any of our commun
 * [Epic Relay](https://github.com/WeLoveJesusChrist/EOSTransport): Epic Online Services
 * [Bubble](https://github.com/Squaresweets/BubbleTransport): Apple GameCenter
 * [Light Reflective Mirror](https://github.com/Derek-R-S/Light-Reflective-Mirror): Self-Hosted Relay
-* [Oculus P2P](https://github.com/hyferg/MirrorOculusP2P): Oculus Platform Service
 
 ## Benchmarks
 * [2022] mischa [400-800 CCU](https://discord.com/channels/343440455738064897/1007519701603205150/1019879180592238603) tests


### PR DESCRIPTION
Switched the EOS Transport link from FakeByte's to Katone's, and removed the Oculus P2P Transport. Could you also update the docs? Thanks!