### PR TITLE
Fix edit-time Null Reference Exception in NetworkInformationPreview

### DIFF
--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -60,7 +60,10 @@ namespace Mirror
         }
 
         GUIContent title;
-        Styles styles = new Styles();
+
+        // Lazy-init fixes NullReferenceException from Styles.labelStyle accessing EditorStyles.label before unity initialises EditorStyles.s_Current
+        Styles _styles;
+        Styles styles => _styles ?? (_styles = new Styles());
 
         public override GUIContent GetPreviewTitle()
         {
@@ -94,10 +97,6 @@ namespace Mirror
 
             if (identity == null)
                 return;
-
-            if (styles == null)
-                styles = new Styles();
-
 
             // padding
             RectOffset previewPadding = new RectOffset(-5, -5, -5, -5);


### PR DESCRIPTION
There's a longstanding null reference exception at edit time when assemblies reload while you have an object with a NetworkIdentity selected. The NRE doesn't break any functionality, but it causes three additional errors. Errors are documented here: https://github.com/MirrorNetworking/Mirror/issues/4033

The error is caused by the NetworkInformationPreview.Styles.labelStyle accessing EditorStyles.label before unity has initialised the EditorStyles.s_Current static reference. NIP.styles is instantiated in the declaration, so the styles constructor is invoked during NIP's instantiation. 

The solution is to delay the Styles constructor until styles is required, which could be done many ways, but i've chose to use a lazy init pattern so its instantiated on first use.  I've been using this in unity 2023.2 and 6000.0 for many months and have never seen the exception or other 3 errors again, and haven't had any other side effects. 

It's a safe change because all styles usages still go through the styles getter, which instantiates a styles instance if the reference is null. It's ever so slightly more expensive with the added null check, but won't affect live games since its editor-only. If some future code change were to set the _styles backing field to null, the styles getter can safely instantiate another styles instance, since it doesn't hold any important state. 

