### PR TITLE
Fixed double "the" in comment for NetworkBehaviour.isLocalPlayer method

### DIFF
--- a/Assets/Mirror/Core/NetworkBehaviour.cs
+++ b/Assets/Mirror/Core/NetworkBehaviour.cs
@@ -65,7 +65,7 @@ namespace Mirror
         /// <summary>Returns true for spawned objects in host mode.</summary>
         public bool isHost => isServer && isClient;
 
-        /// <summary>True if this object is the the client's own local player.</summary>
+        /// <summary>True if this object is the client's own local player.</summary>
         public bool isLocalPlayer => netIdentity.isLocalPlayer;
 
         /// <summary>True if this object is on the server-only, not host.</summary>


### PR DESCRIPTION
removed double 'the' in isLocalPlayer summary comment