### PR TITLE
Fixes NetworkAnimator SetTrigger issue #4052

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -661,21 +661,23 @@ namespace Mirror
                 HandleAnimParamsMsg(networkReader);
         }
 
-        [ClientRpc(includeOwner = false)]
+        [ClientRpc]
         void RpcOnAnimationTriggerClientMessage(int hash)
         {
-            // already handled on server in SetTrigger
-            // or CmdOnAnimationTriggerServerMessage
-            if (!isServer)
+            // already handled on server in SetTrigger or CmdOnAnimationTriggerServerMessage
+            // also is handled on client in SetTrigger if isOwned and syncDirection is ClientToServer
+            bool clientHasAuthority = isOwned && syncDirection == SyncDirection.ClientToServer;
+            if (!isServer && !clientHasAuthority)
                 HandleAnimTriggerMsg(hash);
         }
 
-        [ClientRpc(includeOwner = false)]
+        [ClientRpc]
         void RpcOnAnimationResetTriggerClientMessage(int hash)
         {
-            // already handled on server in ResetTrigger
-            // or CmdOnAnimationResetTriggerServerMessage
-            if (!isServer)
+            // already handled on server in ResetTrigger or CmdOnAnimationResetTriggerServerMessage
+            // also is handled on client in ResetTrigger if isOwned and syncDirection is ClientToServer
+            bool clientHasAuthority = isOwned && syncDirection == SyncDirection.ClientToServer;
+            if (!isServer && !clientHasAuthority)
                 HandleAnimResetTriggerMsg(hash);
         }
 


### PR DESCRIPTION
Fixes #4052. All details is in issue page. 

The fix is removing (includeOwner = false) parameter from ClientRpc attributes. Besides checking isServer it also checks if the current player is in charge of the NetworkAnimator to prevent double trigger set.

Test scene from the issue with the fix applied after pressing keys on both instances:
<img width="2206" height="1043" alt="image" src="https://github.com/user-attachments/assets/efc58654-a80a-47fd-b834-298d652fd007" />

