### PR TITLE
Removed SyncList OnChange and Renamed Callback

### DIFF
--- a/Assets/Mirror/Core/SyncList.cs
+++ b/Assets/Mirror/Core/SyncList.cs
@@ -32,20 +32,11 @@ namespace Mirror
 
         /// <summary>
         /// This is called for all changes to the List.
-        /// <para>For OP_ADD and OP_INSERT, T is the NEW value of the entry.</para>
-        /// <para>For OP_SET and OP_REMOVE, T is the OLD value of the entry.</para>
-        /// <para>For OP_CLEAR, T is default.</para>
-        /// </summary>
-        // TODO deprecate in favor of explicit Callback, later rename Callback to OnChange for consistency with other SyncCollections.
-        public Action<Operation, int, T> OnChange;
-
-        /// <summary>
-        /// This is called for all changes to the List.
         /// Parameters: Operation, index, oldItem, newItem.
         /// Sometimes we need both oldItem and newItem.
         /// Keep for compatibility since 10 years of projects use this.
         /// </summary>
-        public Action<Operation, int, T, T> Callback;
+        public Action<Operation, int, T, T> OnChange;
 
         readonly IList<T> objects;
         readonly IEqualityComparer<T> comparer;
@@ -119,28 +110,23 @@ namespace Mirror
             {
                 case Operation.OP_ADD:
                     OnAdd?.Invoke(itemIndex);
-                    OnChange?.Invoke(op, itemIndex, newItem);
-                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
+                    OnChange?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_INSERT:
                     OnInsert?.Invoke(itemIndex);
-                    OnChange?.Invoke(op, itemIndex, newItem);
-                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
+                    OnChange?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_SET:
                     OnSet?.Invoke(itemIndex, oldItem);
-                    OnChange?.Invoke(op, itemIndex, oldItem);
-                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
+                    OnChange?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_REMOVEAT:
                     OnRemove?.Invoke(itemIndex, oldItem);
-                    OnChange?.Invoke(op, itemIndex, oldItem);
-                    Callback?.Invoke(op, itemIndex, oldItem, newItem);
+                    OnChange?.Invoke(op, itemIndex, oldItem, newItem);
                     break;
                 case Operation.OP_CLEAR:
                     OnClear?.Invoke();
-                    OnChange?.Invoke(op, itemIndex, default);
-                    Callback?.Invoke(op, itemIndex, default, default);
+                    OnChange?.Invoke(op, itemIndex, default, default);
                     break;
             }
         }

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListStructTest.cs
@@ -48,15 +48,7 @@ namespace Mirror.Tests.SyncCollections
             serverList[0] = player;
 
             bool callbackCalled = false;
-            clientList.OnChange = (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem) =>
-            {
-                Assert.That(op == SyncList<TestPlayer>.Operation.OP_SET, Is.True);
-                Assert.That(itemIndex, Is.EqualTo(0));
-                Assert.That(oldItem.item.price, Is.EqualTo(10));
-                Assert.That(clientList[itemIndex].item.price, Is.EqualTo(15));
-                callbackCalled = true;
-            };
-            clientList.Callback = (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
+            clientList.OnChange = (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
             {
                 Assert.That(op == SyncList<TestPlayer>.Operation.OP_SET, Is.True);
                 Assert.That(itemIndex, Is.EqualTo(0));

--- a/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncCollections/SyncListTest.cs
@@ -98,14 +98,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestClear()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_CLEAR));
-                Assert.That(clientSyncList.Count, Is.EqualTo(3));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -131,15 +124,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestInsert()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_INSERT));
-                Assert.That(index, Is.EqualTo(0));
-                Assert.That(clientSyncList[index], Is.EqualTo("yay"));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -174,16 +159,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestSet()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_SET));
-                Assert.That(index, Is.EqualTo(1));
-                Assert.That(oldItem, Is.EqualTo("World"));
-                Assert.That(clientSyncList[index], Is.EqualTo("yay"));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -213,16 +189,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestSetNull()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_SET));
-                Assert.That(index, Is.EqualTo(1));
-                Assert.That(oldItem, Is.EqualTo("World"));
-                Assert.That(clientSyncList[index], Is.EqualTo(null));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -249,7 +216,6 @@ namespace Mirror.Tests.SyncCollections
 
             // clear handlers so we don't get called again
             clientSyncList.OnChange = null;
-            clientSyncList.Callback = null;
             clientSyncList.OnSet = null;
 
             serverSyncList[1] = "yay";
@@ -261,15 +227,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestRemoveAll()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(index, Is.EqualTo(0));
-                Assert.That(oldItem, Is.Not.EqualTo("!"));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -306,15 +264,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestRemoveAt()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(index, Is.EqualTo(1));
-                Assert.That(oldItem, Is.EqualTo("World"));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -342,15 +292,7 @@ namespace Mirror.Tests.SyncCollections
         public void TestRemove()
         {
             bool called = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(index, Is.EqualTo(1));
-                Assert.That(oldItem, Is.EqualTo("World"));
-            };
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 called = true;
 
@@ -488,18 +430,9 @@ namespace Mirror.Tests.SyncCollections
             };
 
             bool changeActionCalled = false;
-            clientSyncList.OnChange = (op, index, newItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 changeActionCalled = true;
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_ADD));
-                Assert.That(index, Is.EqualTo(3));
-                Assert.That(newItem, Is.EqualTo("yay"));
-                Assert.That(clientSyncList[index], Is.EqualTo("yay"));
-            };
-            bool callbackActionCalled = false;
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
-            {
-                callbackActionCalled = true;
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_ADD));
                 Assert.That(index, Is.EqualTo(3));
                 Assert.That(oldItem, Is.Null);
@@ -510,7 +443,6 @@ namespace Mirror.Tests.SyncCollections
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
-            Assert.That(callbackActionCalled, Is.True);
         }
 
         [Test]
@@ -525,16 +457,9 @@ namespace Mirror.Tests.SyncCollections
             };
 
             bool changeActionCalled = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 changeActionCalled = true;
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(index, Is.EqualTo(1));
-            };
-            bool callbackActionCalled = false;
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
-            {
-                callbackActionCalled = true;
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
                 Assert.That(index, Is.EqualTo(1));
             };
@@ -543,7 +468,6 @@ namespace Mirror.Tests.SyncCollections
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
-            Assert.That(callbackActionCalled, Is.True);
         }
 
         [Test]
@@ -558,17 +482,9 @@ namespace Mirror.Tests.SyncCollections
             };
 
             bool changeActionCalled = false;
-            clientSyncList.OnChange = (op, index, oldItem) =>
+            clientSyncList.OnChange = (op, index, oldItem, newItem) =>
             {
                 changeActionCalled = true;
-                Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
-                Assert.That(index, Is.EqualTo(1));
-                Assert.That(oldItem, Is.EqualTo("World"));
-            };
-            bool callbackActionCalled = false;
-            clientSyncList.Callback = (op, index, oldItem, newItem) =>
-            {
-                callbackActionCalled = true;
                 Assert.That(op, Is.EqualTo(SyncList<string>.Operation.OP_REMOVEAT));
                 Assert.That(index, Is.EqualTo(1));
                 Assert.That(oldItem, Is.EqualTo("World"));
@@ -579,7 +495,7 @@ namespace Mirror.Tests.SyncCollections
             SerializeDeltaTo(serverSyncList, clientSyncList);
             Assert.That(actionCalled, Is.True);
             Assert.That(changeActionCalled, Is.True);
-            Assert.That(callbackActionCalled, Is.True);
+            Assert.That(changeActionCalled, Is.True);
         }
 
         [Test]


### PR DESCRIPTION
Removed the old OnChange in SyncList like the TODO said. Also directly renamed Callback to OnChange for consistency, also like the TODO said.

_TODO: "deprecate in favor of explicit Callback, later rename Callback to OnChange for consistency with other SyncCollections."_

_Why not [Obsolete] first?_
In the worst case everyone switches from obsolete OnChange to Callback. TODO implies that this will be renamed later to OnChange. This means everyone would have to go back to their code again to change Callback to OnChange. Simply tear off the plaster quickly here.
Also Obsolete + Rename was not possible due to c# not allowing two Actions with the same name.

**This is propably a big change.**

Also updated the Unit Tests for the SyncList right away. Meaning all old OnChange tests were removed and all Callback names were renamed to Change.
All Unit Tests passed.