### PR TITLE
fix: keep IMGUI in Editor even with UNITY_SERVER; still exclude in server builds

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryHUD.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryHUD.cs
@@ -36,7 +36,7 @@ namespace Mirror.Discovery
         }
 #endif
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (NetworkManager.singleton == null)

--- a/Assets/Mirror/Components/GUIConsole.cs
+++ b/Assets/Mirror/Components/GUIConsole.cs
@@ -105,7 +105,7 @@ namespace Mirror
                 visible = !visible;
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (!visible) return;

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashing3DInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashing3DInterestManagement.cs
@@ -120,7 +120,7 @@ namespace Mirror
             }
         }
 
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         // OnGUI allocates even if it does nothing. avoid in release.
         // slider from dotsnet. it's nice to play around with in the benchmark
         // demo.

--- a/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
+++ b/Assets/Mirror/Components/InterestManagement/SpatialHashing/SpatialHashingInterestManagement.cs
@@ -130,7 +130,7 @@ namespace Mirror
             }
         }
 
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         // OnGUI allocates even if it does nothing. avoid in release.
         // slider from dotsnet. it's nice to play around with in the benchmark
         // demo.

--- a/Assets/Mirror/Components/NetworkPingDisplay.cs
+++ b/Assets/Mirror/Components/NetworkPingDisplay.cs
@@ -16,7 +16,7 @@ namespace Mirror
         public int width = 150;
         public int height = 25;
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             // only while client is active

--- a/Assets/Mirror/Components/NetworkRoomPlayer.cs
+++ b/Assets/Mirror/Components/NetworkRoomPlayer.cs
@@ -123,7 +123,7 @@ namespace Mirror
 
         #endregion
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         #region Optional UI
 
         /// <summary>

--- a/Assets/Mirror/Components/NetworkStatistics.cs
+++ b/Assets/Mirror/Components/NetworkStatistics.cs
@@ -141,7 +141,7 @@ namespace Mirror
             serverIntervalSentBytes = 0;
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             // only show if either server or client active

--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformBase.cs
@@ -486,7 +486,7 @@ namespace Mirror
             }
         }
 
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         // OnGUI allocates even if it does nothing. avoid in release.
         // debug ///////////////////////////////////////////////////////////////
         protected virtual void OnGUI()

--- a/Assets/Mirror/Components/RemoteStatistics.cs
+++ b/Assets/Mirror/Components/RemoteStatistics.cs
@@ -239,7 +239,7 @@ namespace Mirror
             if (isLocalPlayer) UpdateClient();
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (!isLocalPlayer) return;

--- a/Assets/Mirror/Core/NetworkClient.cs
+++ b/Assets/Mirror/Core/NetworkClient.cs
@@ -2003,7 +2003,7 @@ namespace Mirror
             OnTransportExceptionEvent = null;
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         // GUI /////////////////////////////////////////////////////////////////
         // called from NetworkManager to display timeline interpolation status.
         // useful to indicate catchup / slowdown / dynamic adjustment etc.

--- a/Assets/Mirror/Core/NetworkManager.cs
+++ b/Assets/Mirror/Core/NetworkManager.cs
@@ -1459,7 +1459,7 @@ namespace Mirror
         /// <summary>This is called when a host is stopped.</summary>
         public virtual void OnStopHost() { }
 
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         // keep OnGUI even in builds. useful to debug snap interp.
         void OnGUI()
         {

--- a/Assets/Mirror/Core/NetworkManagerHUD.cs
+++ b/Assets/Mirror/Core/NetworkManagerHUD.cs
@@ -19,7 +19,7 @@ namespace Mirror
             manager = GetComponent<NetworkManager>();
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             // If this width is changed, also change offsetX in GUIConsole::OnGUI

--- a/Assets/Mirror/Examples/BenchmarkStinkySteak/Dependencies/netcode-benchmarker-util/Runtime/Scripts/UI/BaseGUIGame.cs
+++ b/Assets/Mirror/Examples/BenchmarkStinkySteak/Dependencies/netcode-benchmarker-util/Runtime/Scripts/UI/BaseGUIGame.cs
@@ -49,7 +49,7 @@ namespace StinkySteak.NetcodeBenchmark
         }
         protected virtual void OnCustomGUI() {}
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         protected virtual void OnGUI()
         {
             GUILayout.BeginArea(new Rect(100, 100, 300, 400));

--- a/Assets/Mirror/Examples/BilliardsPredicted/Ball/WhiteBallPredicted.cs
+++ b/Assets/Mirror/Examples/BilliardsPredicted/Ball/WhiteBallPredicted.cs
@@ -171,7 +171,7 @@ namespace Mirror.Examples.BilliardsPredicted
         }
         */
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         [ClientCallback]
         void OnGUI()
         {

--- a/Assets/Mirror/Examples/HexSpatialHash/Scripts/Hex2DPlayer.cs
+++ b/Assets/Mirror/Examples/HexSpatialHash/Scripts/Hex2DPlayer.cs
@@ -36,7 +36,7 @@ namespace Mirror.Examples.Hex2D
             transform.position += dir.normalized * (Time.deltaTime * speed);
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (isLocalPlayer)

--- a/Assets/Mirror/Examples/HexSpatialHash/Scripts/Hex3DPlayer.cs
+++ b/Assets/Mirror/Examples/HexSpatialHash/Scripts/Hex3DPlayer.cs
@@ -34,7 +34,7 @@ namespace Mirror.Examples.Hex3D
                 transform.Rotate(Vector3.up, 90 * Time.deltaTime);
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (isLocalPlayer)

--- a/Assets/Mirror/Examples/LagCompensation/ClientCube.cs
+++ b/Assets/Mirror/Examples/LagCompensation/ClientCube.cs
@@ -174,7 +174,7 @@ namespace Mirror.Examples.LagCompensationDemo
             r.material.color = originalColor;
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             // display buffer size as number for easier debugging.

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PlayerScore.cs
@@ -18,7 +18,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
 
         public int clientMatchIndex = -1;
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             if (!isServerOnly && !isLocalPlayer && clientMatchIndex < 0)

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomManagerExt.cs
@@ -79,7 +79,7 @@ namespace Mirror.Examples.NetworkRoom
             is set as DontDestroyOnLoad = true.
         */
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         bool showStartButton;
 #endif
 
@@ -88,13 +88,13 @@ namespace Mirror.Examples.NetworkRoom
             // calling the base method calls ServerChangeScene as soon as all players are in Ready state.
             if (Utils.IsHeadless())
                 base.OnRoomServerPlayersReady();
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
             else
                 showStartButton = true;
 #endif
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         public override void OnGUI()
         {
             base.OnGUI();

--- a/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/NetworkRoomPlayerExt.cs
@@ -30,7 +30,7 @@ namespace Mirror.Examples.NetworkRoom
             //Debug.Log($"ReadyStateChanged {newReadyState}");
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         public override void OnGUI()
         {
             base.OnGUI();

--- a/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
@@ -11,7 +11,7 @@ namespace Mirror.Examples.NetworkRoom
         [SyncVar]
         public uint score;
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             GUI.Box(new Rect(10f + (index * 110), 10f, 100f, 25f), $"P{index}: {score:0000000}");

--- a/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
+++ b/Assets/Mirror/Examples/Snapshot Interpolation/ClientCube.cs
@@ -156,7 +156,7 @@ namespace Mirror.Examples.SnapshotInterpolationDemo
                 render.material.color = defaultColor;
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         void OnGUI()
         {
             // display buffer size as number for easier debugging.

--- a/Assets/Mirror/Examples/SyncDirection/Player.cs
+++ b/Assets/Mirror/Examples/SyncDirection/Player.cs
@@ -42,7 +42,7 @@ namespace Mirror.Examples.SyncDir // ".SyncDirection" would overshadow the enum
             }
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         // show instructions
         void OnGUI()
         {

--- a/Assets/Mirror/Examples/_Common/Scripts/FPS.cs
+++ b/Assets/Mirror/Examples/_Common/Scripts/FPS.cs
@@ -28,7 +28,7 @@ namespace Mirror.Examples.Common
             }
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         protected void OnGUI()
         {
             if (!showGUI) return;

--- a/Assets/Mirror/Transports/Edgegap/EdgegapLobby/LobbyServiceCreateDialogue.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapLobby/LobbyServiceCreateDialogue.cs
@@ -20,7 +20,7 @@ namespace Edgegap
             titleContent = new GUIContent("Edgegap Lobby Service Setup");
         }
 
-#if !UNITY_SERVER
+#if !UNITY_SERVER || UNITY_EDITOR
         private void OnGUI()
         {
             if (waitingCreate)

--- a/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
+++ b/Assets/Mirror/Transports/Edgegap/EdgegapRelay/EdgegapKcpTransport.cs
@@ -144,13 +144,14 @@ namespace Edgegap
             GUILayout.EndArea();
         }
 
-#if !UNITY_SERVER && DEBUG
+
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         protected override void OnGUI()
         {
             base.OnGUI();
             if (relayGUI) OnGUIRelay();
         }
-#elif !UNITY_SERVER && !DEBUG
+#elif UNITY_EDITOR || (!UNITY_SERVER && !DEBUG)
         // base OnGUI only shows in editor & development builds.
         // here we always show it because we need the sessionid & userid buttons.
         void OnGUI()

--- a/Assets/Mirror/Transports/KCP/KcpTransport.cs
+++ b/Assets/Mirror/Transports/KCP/KcpTransport.cs
@@ -324,7 +324,7 @@ namespace kcp2k
         }
 
         // OnGUI allocates even if it does nothing. avoid in release.
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         protected virtual void OnGUI()
         {
             if (statisticsGUI) OnGUIStatistics();

--- a/Assets/Mirror/Transports/KCP/ThreadedKcpTransport.cs
+++ b/Assets/Mirror/Transports/KCP/ThreadedKcpTransport.cs
@@ -283,7 +283,7 @@ namespace kcp2k
         }
 
         // OnGUI allocates even if it does nothing. avoid in release.
-#if !UNITY_SERVER && DEBUG
+#if UNITY_EDITOR || (!UNITY_SERVER && DEBUG)
         protected virtual void OnGUI()
         {
             if (statisticsGUI) OnGUIStatistics();


### PR DESCRIPTION
## When we are on the server build option it is difficult to test your application

Very often, especially in the early stages of creating an application, you need to test all the time and change something every time, build a new build and test again, and in this case, you have to switch from platform to platform every time. And this is both annoying and takes a lot of time, so my change solves this issue, that is, you can stay on the server build option and at the same time instantly test your application in the EDITOR and build builds if necessary without having to switch between build options.

![Server build option](https://i.ibb.co/FqYmC6Km/Screenshot-2025-09-05-184447.png)

### A) Before (regression — Editor with Dedicated Server target)
**Steps**
1. Switch Build Target to **Dedicated Server**.
2. Enter Play Mode in **Unity Editor**.
3. Open any Mirror IMGUI panel (e.g., NetworkManagerHUD/NetGraph).
4. **Observed:** IMGUI does **not** render (due to `#if !UNITY_SERVER `).

**Screenshot**
![Before — Editor (Dedicated Server target), IMGUI missing](https://i.ibb.co/VYDmpXGx/Screenshot-2025-09-05-184756.png)

And in this case, we have to additionally write a script for each test so that we can first connect to the server. And then, using scripts through the debuglock, output the data that, in theory, the ONGUI methods should show.

![Before — Editor (Dedicated Server target), IMGUI missing](https://i.ibb.co/23fjQzYg/Screenshot-2025-09-05-185127.png)

---

### B) After (this PR — Editor with Dedicated Server target)
**Steps**
1. Same as above (Dedicated Server target, Play Mode).
2. **Observed:** IMGUI **renders** in Editor (`#if !UNITY_SERVER || UNITY_EDITOR `).

**Screenshot**
![After — Editor (Dedicated Server target), IMGUI visible](https://i.ibb.co/5Wv0BXv3/Screenshot-2025-09-05-184609.png)

And now it is convenient to test your application and you do not need to switch to another version of the assembly every time after you have built a test server assembly in order to be able to test your application in UNITY EDITOR
And now you can conveniently control and also see all the data that you need during testing.

![After — Editor (Dedicated Server target), IMGUI visible](https://i.ibb.co/4ZZHrTDf/Screenshot-2025-09-05-184648.png)

---

### C) Server Player Build (still excluded)
**Steps**
1. Build **Server** player (Dev/Release).
2. Run the headless/server build.
3. **Observed:** IMGUI is **stripped** in server players (unchanged behavior).


