### PR TITLE
Reset last snapshot in NetworkTransformUnreliable

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
+++ b/Assets/Mirror/Components/NetworkTransform/NetworkTransformUnreliable.cs
@@ -494,5 +494,12 @@ namespace Mirror
                 scale = syncData.scale;
             }
         }
+
+        public override void ResetState()
+        {
+            base.ResetState();
+
+            lastSnapshot = default;
+        }
     }
 }


### PR DESCRIPTION
When authority is changed, `lastSnapshot` will continue to hold an outdated value
This can cause change detection to incorrectly omit a position component after authority changes

e.g. my case:
1. Client A has authority over object and moves it to Y=2
2. The object is released and falls to Y=0 under another authority
3. The object is picked up by Client A again and moved back to Y=2
4. Since `lastSnapshot` still contains Y=2, PosY is not marked as changed
5. Other clients won't obtain correct Y value